### PR TITLE
Update compositors info

### DIFF
--- a/src/data/compositors/kwin.json
+++ b/src/data/compositors/kwin.json
@@ -1,5 +1,5 @@
 {
-  "generationTimestamp": 1660046621507,
+  "generationTimestamp": 1668530316496,
   "globals": [
     {
       "interface": "wl_compositor",
@@ -71,7 +71,7 @@
     },
     {
       "interface": "org_kde_plasma_shell",
-      "version": 7
+      "version": 8
     },
     {
       "interface": "org_kde_kwin_appmenu_manager",
@@ -143,7 +143,7 @@
     },
     {
       "interface": "wl_output",
-      "version": 3
+      "version": 4
     },
     {
       "interface": "zwp_text_input_manager_v2",

--- a/src/data/compositors/mutter.json
+++ b/src/data/compositors/mutter.json
@@ -1,5 +1,5 @@
 {
-  "generationTimestamp": 1660046539976,
+  "generationTimestamp": 1668530201669,
   "globals": [
     {
       "interface": "wl_compositor",
@@ -30,20 +30,12 @@
       "version": 1
     },
     {
-      "interface": "gtk_primary_selection_device_manager",
-      "version": 1
-    },
-    {
       "interface": "wl_subcompositor",
       "version": 1
     },
     {
       "interface": "xdg_wm_base",
       "version": 4
-    },
-    {
-      "interface": "zxdg_shell_v6",
-      "version": 1
     },
     {
       "interface": "gtk_shell1",
@@ -63,7 +55,7 @@
     },
     {
       "interface": "wl_seat",
-      "version": 5
+      "version": 8
     },
     {
       "interface": "zwp_relative_pointer_manager_v1",
@@ -84,6 +76,10 @@
     {
       "interface": "zwp_linux_dmabuf_v1",
       "version": 4
+    },
+    {
+      "interface": "wp_single_pixel_buffer_manager_v1",
+      "version": 1
     },
     {
       "interface": "zwp_keyboard_shortcuts_inhibit_manager_v1",


### PR DESCRIPTION
There were some changes in supported protocols in kwin and mutter (on arch), so here we are, this regenerates compositors json data.