### PR TITLE
Mir supports idle inhibit, pointer constraints & relative pointer

### DIFF
--- a/src/data/compositors/mir.json
+++ b/src/data/compositors/mir.json
@@ -1,5 +1,5 @@
 {
-  "generationTimestamp": 1673093842544,
+  "generationTimestamp": 1673367453755,
   "globals": [
     {
       "interface": "zwp_linux_dmabuf_v1",
@@ -46,6 +46,14 @@
       "version": 2
     },
     {
+      "interface": "zwp_relative_pointer_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_pointer_constraints_v1",
+      "version": 1
+    },
+    {
       "interface": "zwp_virtual_keyboard_manager_v1",
       "version": 1
     },
@@ -67,6 +75,10 @@
     },
     {
       "interface": "zwp_input_method_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_idle_inhibit_manager_v1",
       "version": 1
     },
     {


### PR DESCRIPTION
I found out about `mir_demo_server --add-wayland-extensions all` which enables even more Wayland extensions supported by Mir:
```
$ mir_demo_server --help
...
  --wayland-extensions arg              Colon-separated list of Wayland
                                        extensions to enable. If used, default
                                        extensions will NOT be enabled unless
                                        specified. Default extensions:
                                          ...
                                        Additional supported extensions:
                                          zwp_idle_inhibit_manager_v1
                                          zwp_pointer_constraints_v1
                                          zwp_relative_pointer_manager_v1
  --add-wayland-extensions arg          Wayland extensions to enable in
                                        addition to default extensions. Use
                                        `all` to enable all supported
                                        extensions.
```