### PR TITLE
Update URLs, deprecate KDE's screencast.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Easily browse and read Wayland protocols documentation.
 
 ## Motivation for this project
 
-Wayland protocols are published as XML files. While the [core Wayland protocol](https://github.com/wayland-project/wayland/blob/master/protocol/wayland.xml) specification is also available in HTML format for reading [online](https://wayland.freedesktop.org/docs/html/apa.html), that's not the case for all the [other](https://github.com/wayland-project/wayland-protocols/tree/master/unstable) [Wayland](https://github.com/wayland-project/wayland-protocols/tree/master/stable) [protocols](https://github.com/swaywm/wlr-protocols/tree/master/unstable) which are not part of the core protocol.
+Wayland protocols are published as XML files. While the [core Wayland protocol](https://gitlab.freedesktop.org/wayland/wayland/-/blob/main/protocol/wayland.xml) specification is also available in HTML format for reading [online](https://wayland.freedesktop.org/docs/html/apa.html), that's not the case for all the [other](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tree/main/unstable) [Wayland](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tree/main/stable) [protocols](https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/tree/master/unstable) which are not part of the core protocol.
 
 This project attempts to fill this gap by parsing the XML protocol files and converting them to HTML in order to make it easy to browse and read them on the web.
 

--- a/scripts/bin/regenerate-protocols-data.ts
+++ b/scripts/bin/regenerate-protocols-data.ts
@@ -31,7 +31,7 @@ const deprecatedProtocols = [
     'xdg-shell-unstable-v6.xml',
     /**
      * Deprecated KDE protocols
-     * https://github.com/KDE/plasma-wayland-protocols/blob/e89f46fa782713f004a65879c56e844fce63257b/src/protocols/TODOKF6.md
+     * https://invent.kde.org/libraries/plasma-wayland-protocols/-/blob/78fc6ee77334a147986f01c6d3c6e1b99af1a333/src/protocols/TODOKF6.md
      */
     'fullscreen-shell.xml',
     'remote-access.xml',
@@ -39,6 +39,7 @@ const deprecatedProtocols = [
     'text-input.xml',
     'text-input-unstable-v2.xml',
     'wayland-eglstream-controller.xml',
+    'screencast.xml',
     /**
      * Unused libwayland protocol
      */

--- a/src/model/protocol-source-link-builder.ts
+++ b/src/model/protocol-source-link-builder.ts
@@ -72,12 +72,12 @@ const sourceRepositoryUrls: Record<
             'https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/blob/master/${stability}/${protocol}.xml',
     },
     [WaylandProtocolSource.KDEProtocols]: {
-        repositoryUrl: 'https://github.com/KDE/plasma-wayland-protocols',
+        repositoryUrl: 'https://invent.kde.org/libraries/plasma-wayland-protocols',
         stabilityUrl:
-            'https://github.com/KDE/plasma-wayland-protocols/tree/master/src/protocols',
+            'https://invent.kde.org/libraries/plasma-wayland-protocols/-/tree/master/src/protocols',
         protocolUrl:
             // eslint-disable-next-line no-template-curly-in-string
-            'https://github.com/KDE/plasma-wayland-protocols/blob/master/src/protocols/${protocol}.xml',
+            'https://invent.kde.org/libraries/plasma-wayland-protocols/-/blob/master/src/protocols/${protocol}.xml',
     },
     [WaylandProtocolSource.WestonProtocols]: {
         repositoryUrl: 'https://gitlab.freedesktop.org/wayland/weston',


### PR DESCRIPTION
KDE deprecated `screencast.xml` in favor of `zkde-screencast-unstable-v1.xml`: https://invent.kde.org/libraries/plasma-wayland-protocols/-/commit/a3ad6a6a9acb6b62d4c99e841d7c109530366c8f

Also update various URLs to be more up-to-date, as `wlroots` has completely archived their GitHub repos and the Wayland ones are out-of-date (without being archived). Technically the KDE repos seem to be an up-to-date mirror of their [invent.kde.org GitLab instance](https://invent.kde.org) but I think we should replace them anyway to point to the proper upstream where changes can be contributed etc.

`src/model/protocol-source-link-builder.ts` still has `GitServiceProvider.GitHub` entries for both https://github.com/wayland-project/wayland & https://github.com/wayland-project/wayland-protocols, I think those should be removed (due them being out of date as I mentioned)  too but I'm not sure how to proceed with that yet, so I'm marking this PR as a draft.