### PR TITLE
Update compositor data for Mir 2.13

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "protocols/wayland"]
 	path = protocols/wayland
-	url = https://github.com/wayland-project/wayland-protocols.git
+	url = https://gitlab.freedesktop.org/wayland/wayland-protocols.git
 [submodule "protocols/wlr"]
 	path = protocols/wlr
 	url = https://gitlab.freedesktop.org/wlroots/wlr-protocols.git
 [submodule "protocols/kde"]
 	path = protocols/kde
-	url = https://github.com/KDE/plasma-wayland-protocols.git
+	url = https://invent.kde.org/libraries/plasma-wayland-protocols.git
 [submodule "protocols/weston"]
 	path = protocols/weston
 	url = https://gitlab.freedesktop.org/wayland/weston.git
 [submodule "protocols/libwayland"]
 	path = protocols/libwayland
-	url = https://github.com/wayland-project/wayland
+	url = https://gitlab.freedesktop.org/wayland/wayland.git

--- a/src/data/compositors/mir.json
+++ b/src/data/compositors/mir.json
@@ -1,5 +1,5 @@
 {
-  "generationTimestamp": 1674145931206,
+  "generationTimestamp": 1679409485385,
   "globals": [
     {
       "interface": "zwp_linux_dmabuf_v1",
@@ -31,7 +31,7 @@
     },
     {
       "interface": "xdg_wm_base",
-      "version": 1
+      "version": 5
     },
     {
       "interface": "zwlr_layer_shell_v1",
@@ -95,7 +95,7 @@
     },
     {
       "interface": "wl_output",
-      "version": 3
+      "version": 4
     }
   ]
 }


### PR DESCRIPTION
Provides updated implementations of [`xdg-shell`](https://wayland.app/protocols/xdg-shell#compositor-support) & [`wl_output`](https://wayland.app/protocols/wayland#compositor-support): https://github.com/MirServer/mir/releases/tag/v2.13.0