### PR TITLE
Initial Gitlab protocol source

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,12 @@
   to = "/protocols/kde-zkde-screencast-unstable-v1"
 
 [[redirects]]
+  from = "/protocols/git/*"
+  to = "/protocols/git.html"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/protocols/*"
   to = "/protocols/404.html"
   status = 404

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,8 +15,8 @@
   to = "/protocols/kde-zkde-screencast-unstable-v1"
 
 [[redirects]]
-  from = "/protocols/git/*"
-  to = "/protocols/git.html"
+  from = "/protocols/wayland-protocols/*"
+  to = "/protocols/wayland-protocols-gitlab.html"
   status = 200
   force = true
 

--- a/scripts/bin/convert-wayland-xml-to-json.ts
+++ b/scripts/bin/convert-wayland-xml-to-json.ts
@@ -2,7 +2,7 @@ import { XMLParser } from 'fast-xml-parser'
 import { readFileSync } from 'fs'
 import { argv } from 'process'
 import { WaylandElementType } from '../../src/model/wayland'
-import { transformXMLElement } from '../lib/xml-protocol-transformers'
+import { transformXMLElement } from '../../src/lib/xml-protocol-transformers'
 
 async function main(fileName: string) {
     const fileData = readFileSync(fileName, 'utf-8')

--- a/scripts/bin/regenerate-protocols-data.ts
+++ b/scripts/bin/regenerate-protocols-data.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { WaylandElementType } from '../../src/model/wayland'
 import { findXMLFiles, jsonFileNameFor } from '../lib/utils'
-import { transformXMLElement } from '../lib/xml-protocol-transformers'
+import { transformXMLElement } from '../../src/lib/xml-protocol-transformers'
 
 const relativeProtocolDirs = [
     path.join('protocols', 'libwayland', 'protocol'),

--- a/scripts/bin/render-static-html.tsx
+++ b/scripts/bin/render-static-html.tsx
@@ -38,6 +38,11 @@ function allPageDescriptors(): StaticPageDescriptor[] {
             fileName: '404.html',
             pageTitle: '404 - Page not found',
         },
+        {
+            routerPath: '/git/wayland-protocols/0',
+            fileName: 'git.html',
+            pageTitle: 'Git',
+        },
     ]
 
     const protocolPages: StaticPageDescriptor[] = waylandProtocolRegistry.protocols.map(

--- a/scripts/bin/render-static-html.tsx
+++ b/scripts/bin/render-static-html.tsx
@@ -39,8 +39,8 @@ function allPageDescriptors(): StaticPageDescriptor[] {
             pageTitle: '404 - Page not found',
         },
         {
-            routerPath: '/git/wayland-protocols/0',
-            fileName: 'git.html',
+            routerPath: '/wayland-protocols/0',
+            fileName: 'wayland-protocols-gitlab.html',
             pageTitle: 'Git',
         },
     ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,17 +6,22 @@ import { WaylandProtocol } from './components/WaylandProtocol'
 import { waylandProtocolRegistry } from './data/protocol-registry'
 import { NotFound } from './pages/404'
 import { Homepage } from './pages/Homepage'
+import { GitLab } from './pages/GitLab'
 
 function App() {
     let contentView = <Homepage />
     let outlineView = null
 
+    const [isGitlab, gitlabParams] = useRoute<{ iid: string }>('/git/wayland-protocols/:iid')
+
     const [match, params] = useRoute<{ protocolId: string }>('/:protocolId')
-    const isHomepage = !match
+    const isHomepage = !match && !isGitlab
 
     useAnalytics().trackPageview()
 
-    if (match && params?.protocolId) {
+    if (isGitlab && gitlabParams?.iid) {
+        return <GitLab iid={gitlabParams?.iid}></GitLab>
+    } else if (match && params?.protocolId) {
         const protocolWithMetadata = match
             ? waylandProtocolRegistry.getProtocolWithMetadata(params.protocolId)
             : null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
     let contentView = <Homepage />
     let outlineView = null
 
-    const [isGitlab, gitlabParams] = useRoute<{ iid: string }>('/git/wayland-protocols/:iid')
+    const [isGitlab, gitlabParams] = useRoute<{ iid: string }>('/wayland-protocols/:iid')
 
     const [match, params] = useRoute<{ protocolId: string }>('/:protocolId')
     const isHomepage = !match && !isGitlab

--- a/src/lib/xml-protocol-transformers.ts
+++ b/src/lib/xml-protocol-transformers.ts
@@ -11,7 +11,13 @@ import {
     WaylandProtocol,
     WaylandRequest,
 } from '../../src/model/wayland'
-import { coerceArray } from './utils'
+
+export function coerceArray<T = any>(value: T | T[]): T[] {
+    if (value === null || value === undefined) return []
+
+    return Array.isArray(value) ? value : [value]
+}
+
 
 type WaylandXMLElementTransformer = (xmlData: any) => WaylandElement
 

--- a/src/pages/GitLab.tsx
+++ b/src/pages/GitLab.tsx
@@ -1,0 +1,201 @@
+import { MultiColumnLayout } from '../components/layout/MultiColumnLayout'
+import { WaylandProtocolOutline } from '../components/outline/WaylandProtocolOutline'
+import { WaylandProtocol } from '../components/WaylandProtocol'
+import { useEffect, useState } from 'react'
+
+import { XMLParser } from 'fast-xml-parser'
+import {
+    WaylandElementType,
+    WaylandProtocol as WaylandProtocolModel,
+} from '../model/wayland'
+import { transformXMLElement } from '../lib/xml-protocol-transformers'
+import {
+    WaylandProtocolSource,
+    WaylandProtocolStability,
+} from '../model/wayland-protocol-metadata'
+
+interface GitLabFile {
+    name: string
+    webPath: string
+    path: string
+    protocol: WaylandProtocolModel | undefined
+}
+
+async function getMergeRequestFiles(
+    mr: GitLabMergeRequest
+): Promise<GitLabFile[]> {
+    const paths = mr.diffStats
+        .filter((diff) => diff.path.endsWith('.xml'))
+        .map(({ path }) => path)
+
+    const data = JSON.stringify({
+        query: `{
+      project(fullPath: "${mr.sourceProject.fullPath}") {
+        repository {
+          blobs(ref: "${mr.sourceBranch}", paths: ${JSON.stringify(paths)}) {
+            nodes {
+              name
+              webPath
+              path
+              rawBlob
+            }
+          }
+        }
+      }
+    }`,
+    })
+
+    const response = await fetch('https://gitlab.freedesktop.org/api/graphql', {
+        method: 'post',
+        body: data,
+        headers: new Headers({
+            'Content-Type': 'application/json',
+            'Content-Length': data.length.toString(),
+        }),
+    })
+
+    const nodes: {
+        name: string
+        webPath: string
+        path: string
+        rawBlob: string
+    }[] = (await response.json()).data.project.repository.blobs.nodes
+
+    return nodes.map((node) => {
+        const parser = new XMLParser({
+            ignoreAttributes: false,
+            attributeNamePrefix: '',
+        })
+        const xmlData = parser.parse(node.rawBlob)
+        const protocol = transformXMLElement<WaylandProtocolModel>(
+            xmlData['protocol'],
+            WaylandElementType.Protocol
+        )
+
+        return {
+            name: node.name,
+            webPath: node.webPath,
+            path: node.path,
+            protocol,
+        }
+    })
+}
+
+interface GitLabMergeRequest {
+    iid: number
+    title: string
+    author: { name: string }
+    sourceProject: { fullPath: string }
+    sourceBranch: string
+    diffStats: { path: string }[]
+}
+
+async function getMergeRequest(iid: string): Promise<GitLabMergeRequest> {
+    const data = JSON.stringify({
+        query: `{
+        project(fullPath: "wayland/wayland-protocols") {
+          mergeRequests ( iids: ["${iid}"] ) {
+            nodes {
+              iid
+              title
+              author { name }
+              sourceProject { fullPath }
+              sourceBranch
+              diffStats { path }
+            }
+          }
+        }
+      }`,
+    })
+
+    const response = await fetch('https://gitlab.freedesktop.org/api/graphql', {
+        method: 'post',
+        body: data,
+        headers: new Headers({
+            'Content-Type': 'application/json',
+            'Content-Length': data.length.toString(),
+        }),
+    })
+
+    const json = await response.json()
+    return json.data.project.mergeRequests.nodes[0]
+}
+
+export const GitLab: React.FC<{ iid: string }> = ({ iid }) => {
+    const [files, setFiles] = useState<GitLabFile[] | null>(null)
+
+    useEffect(() => {
+        getMergeRequest(iid).then(async (mr) => {
+            mr.diffStats = mr.diffStats.filter(({ path }) =>
+                path.endsWith('.xml')
+            )
+
+            const protocols = (await getMergeRequestFiles(mr)).filter(
+                (file) => file.protocol !== undefined
+            )
+
+            setFiles(protocols)
+        }).catch((_) => {
+            setFiles([])
+        })
+    }, [iid])
+
+    const contentView = files ? (
+        <div>
+            {files.map((file) => (
+                <div key={file.path} id={file.name}>
+                    <WaylandProtocol
+                        element={file.protocol as any}
+                        metadata={{
+                            id: file.name.substring(0, file.name.length - 4),
+                            name: file.protocol?.name
+                                ? file.protocol.name
+                                : file.name,
+                            source: WaylandProtocolSource.External,
+                            stability: WaylandProtocolStability.Unstable,
+                            externalUrl: `https://gitlab.freedesktop.org${file.webPath}`,
+                        }}
+                    />
+                </div>
+            ))}
+            {files.length === 0 ? <h1 className="text-center text-2xl mt-5">Not found</h1> : null}
+        </div>
+    ) : (
+        <h1 className="text-center text-2xl mt-5">
+          Loading...
+        </h1>
+    )
+
+    const outlineView = files && files.length !== 0 ? (
+        <div>
+            {files.map((file) => (
+                <div key={file.name}>
+                    {files.length > 1 ? (
+                        <a
+                            href={`#${file.name}`}
+                            className="
+                                group flex items-center text-sm font-medium
+                                bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-800
+                                border-l-4 border-black dark:border-white
+                                hover:text-purple-500 hover:border-purple-600
+                                py-2 px-3 mt-2 mb-2
+                            "
+                        >
+                            <span className="truncate">{file.name}</span>
+                        </a>
+                    ) : null}
+                    <WaylandProtocolOutline
+                        key={file.name}
+                        element={file.protocol as any}
+                    />
+                </div>
+            ))}
+        </div>
+    ) : null
+
+    return (
+        <MultiColumnLayout outlineView={outlineView} hideSidebar={false}>
+            {contentView}
+        </MultiColumnLayout>
+    )
+}


### PR DESCRIPTION
The idea is to load WIP protocols from wayland-protocols, so it is possible to read protocols that are not merged yet.
eg. `https://wayland.app/protocols/wayland-protocols/124` would download and render screen copy protocol.

Examples:
MR with two files: https://deploy-preview-32--wayland-explorer.netlify.app/protocols/wayland-protocols/124
MR with one file: https://deploy-preview-32--wayland-explorer.netlify.app/protocols/wayland-protocols/211