### PR TITLE
UI improvement for header for mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-pt-16 xl:scroll-pt-0">
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/src/components/WaylandInterface.tsx
+++ b/src/components/WaylandInterface.tsx
@@ -21,10 +21,10 @@ export const WaylandInterface: React.FC<
                 <a
                     href={`#${element.name}`}
                     title={`${element.name} interface`}
-                    className={`${colors.Interface} truncate`}
+                    className={`${colors.Interface}`}
                 >
                     <span className="codicon codicon-symbol-interface mr-1"></span>
-                    <span className="mr-1">{element.name}</span>
+                    <span className="mr-1 break-all">{element.name}</span>
                 </a>
             </h2>
 

--- a/src/components/WaylandRequest.tsx
+++ b/src/components/WaylandRequest.tsx
@@ -21,7 +21,7 @@ export const WaylandRequest: React.FC<
                     <span className={`hidden md:inline ${colors.Interface}`}>
                         {interfaceName}::
                     </span>
-                    <span>{element.name}</span>
+                    <span className="break-all">{element.name}</span>
                 </span>
             </a>
             {(element.requestType || element.since) && (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ export const Header: React.FC<{
     setIsSidebarOpen: (open: boolean) => void
     setIsOutlineOpen: (open: boolean) => void
 }> = ({ setIsSidebarOpen, setIsOutlineOpen, showOutlineButton }) => (
-    <header className="xl:hidden w-full">
+    <header className="fixed top-0 xl:hidden w-full z-10">
         <div className="relative z-10 shrink-0 h-16 bg-gray-50 border-b border-gray-200 shadow-sm flex dark:bg-gray-900 dark:border-gray-700">
             <button
                 className="border-r border-gray-200 px-4 text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:border-gray-700"

--- a/src/components/layout/MultiColumnLayout.tsx
+++ b/src/components/layout/MultiColumnLayout.tsx
@@ -31,7 +31,7 @@ export const MultiColumnLayout: React.FC<{
             />
 
             <div
-                className={`mx-auto px-4 sm:px-6 lg:px-8 lg:grid lg:grid-cols-12 lg:gap-8 xl:pl-0 ${
+                className={`mx-auto px-4 pt-16 sm:px-6 lg:px-8 lg:grid lg:grid-cols-12 lg:gap-8 xl:pl-0 xl:pt-0 ${
                     hideSidebar ? 'xl:pr-0' : ''
                 }`}
             >


### PR DESCRIPTION
fix #16:

fixed header
------------

implement with `fixed` `top-0` with content correction `pt-16` ( `<header>`'s `h-16` )
anchor positing correction using `scroll-pt-16` ( `<header>`'s `h-16` )

Protocols overlaps header
-------------------------

Inspected by chrome devtools's Layer tool, `<div class="relative rounded-lg border ...">` is `Overlaps other composited content`.

![图片](https://github.com/vially/wayland-explorer/assets/22849803/467440b6-0977-4b9b-af93-14ccaa374c5a)

fix with `z-10`

Discovered issue
----------------

Some content's table is overflow, cause horizontal scrollbar and `<header>` clipping.