### PR TITLE
Update compositor data for Mir 2.14

### DIFF
--- a/src/data/compositors/mir.json
+++ b/src/data/compositors/mir.json
@@ -1,5 +1,5 @@
 {
-  "generationTimestamp": 1679409485385,
+  "generationTimestamp": 1690029459060,
   "globals": [
     {
       "interface": "zwp_linux_dmabuf_v1",
@@ -87,6 +87,10 @@
     },
     {
       "interface": "zwp_primary_selection_device_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "ext_session_lock_manager_v1",
       "version": 1
     },
     {


### PR DESCRIPTION
Provides an [`ext-session-lock-v1`](https://wayland.app/protocols/ext-session-lock-v1) implementation: https://github.com/MirServer/mir/releases/tag/v2.14.0