### PR TITLE
Display compositor info generation timestamp

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -108,6 +108,7 @@ const CanIUseTable: React.FC<{
                                     className="w-5 ml-2 dark:invert"
                                 />
                             </div>
+                            <div className="text-xs text-gray-500 mt-1" title="Date of last update">{new Date(comp.info.generationTimestamp).toLocaleDateString()}</div>
                         </th>
                     ))}
                 </tr>


### PR DESCRIPTION
Display when the compositor data was generated:

![image](https://github.com/vially/wayland-explorer/assets/20758186/b19c5b21-1e8b-4e3f-bf7a-e009afd3a7ed)
