### PR TITLE
Add .editorconfig with 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root=true
+
+[*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Saves me from having to set my text editor to use 4 spaces for indentations.