### PR TITLE
Add `gamescope` compositor and mention `wlprobe` in new `README`

### DIFF
--- a/public/logos/Steam_Deck.svg
+++ b/public/logos/Steam_Deck.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="89" height="115" viewBox="0 0 89 115" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M65.5648 57.5C65.5648 37.1433 49.1526 20.641 28.9072 20.641V0C60.4901 0 86.093 25.7436 86.093 57.5C86.093 89.2564 60.4901 115 28.9072 115V94.359C49.1526 94.359 65.5648 77.8567 65.5648 57.5Z" fill="black"/>
+  <circle cx="28.5929" cy="57.5001" r="28.5929" fill="url(#paint0_linear)"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="-22.0009" y1="39.4667" x2="45.1598" y2="71.8891" gradientUnits="userSpaceOnUse">
+      <stop offset="0.106991" stop-color="#C957E6"/>
+      <stop offset="1" stop-color="#1A9FFF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/data/compositor-registry.ts
+++ b/src/data/compositor-registry.ts
@@ -46,4 +46,10 @@ export const compositorRegistry: CompositorRegistryItem[] = [
         icon: 'mir',
         info: require('./compositors/mir.json'),
     },
+    {
+        id: 'gamescope',
+        name: 'gamescope',
+        icon: 'Steam_Deck',
+        info: require('./compositors/gamescope.json'),
+    },
 ]

--- a/src/data/compositors/README.md
+++ b/src/data/compositors/README.md
@@ -1,0 +1,3 @@
+# Regenerating or adding new files
+
+These files are generated via [`wlprobe`](https://github.com/PolyMeilex/wlprobe), a tool similar to `wayland-info` but [with JSON support](https://gitlab.freedesktop.org/wayland/wayland-utils/-/issues/2).  Refer to its README for usage instructions.

--- a/src/data/compositors/gamescope.json
+++ b/src/data/compositors/gamescope.json
@@ -1,0 +1,65 @@
+{
+  "generationTimestamp": 1702565286938,
+  "globals": [
+    {
+      "interface": "wl_shm",
+      "version": 1
+    },
+    {
+      "interface": "wl_drm",
+      "version": 2
+    },
+    {
+      "interface": "zwp_linux_dmabuf_v1",
+      "version": 4
+    },
+    {
+      "interface": "wl_compositor",
+      "version": 5
+    },
+    {
+      "interface": "gamescope_input_method_manager",
+      "version": 2
+    },
+    {
+      "interface": "gamescope_xwayland",
+      "version": 1
+    },
+    {
+      "interface": "gamescope_swapchain_factory",
+      "version": 1
+    },
+    {
+      "interface": "gamescope_pipewire",
+      "version": 1
+    },
+    {
+      "interface": "gamescope_control",
+      "version": 2
+    },
+    {
+      "interface": "gamescope_tearing_control_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_presentation",
+      "version": 1
+    },
+    {
+      "interface": "gamescope_commit_queue_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "xdg_wm_base",
+      "version": 3
+    },
+    {
+      "interface": "wl_seat",
+      "version": 8
+    },
+    {
+      "interface": "wl_output",
+      "version": 4
+    }
+  ]
+}


### PR DESCRIPTION
Gamescope only supports Wayland when ran with `--expose-wayland`, and only exposes a limited set of protocols from `core` (i.e. `wl_subcompositor` is not supported, which Rust's `winit` currently relies on).  This information may be helpful to developers who are targeting gamescope's Wayland support.

This is generated from version `3.13.17-1` (ArchLinux package).

Also add a README as suggested in [#9] to make it easier for future readers to know how to (re)generate these files.

[#9]: https://github.com/vially/wayland-explorer/pull/9#issuecomment-1855975715
