### PR TITLE
gamescope: Remove gradient from Steam Deck logo

### DIFF
--- a/public/logos/Steam_Deck.svg
+++ b/public/logos/Steam_Deck.svg
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="89" height="115" viewBox="0 0 89 115" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path fill-rule="evenodd" clip-rule="evenodd" d="M65.5648 57.5C65.5648 37.1433 49.1526 20.641 28.9072 20.641V0C60.4901 0 86.093 25.7436 86.093 57.5C86.093 89.2564 60.4901 115 28.9072 115V94.359C49.1526 94.359 65.5648 77.8567 65.5648 57.5Z" fill="black"/>
-  <circle cx="28.5929" cy="57.5001" r="28.5929" fill="url(#paint0_linear)"/>
-  <defs>
-    <linearGradient id="paint0_linear" x1="-22.0009" y1="39.4667" x2="45.1598" y2="71.8891" gradientUnits="userSpaceOnUse">
-      <stop offset="0.106991" stop-color="#C957E6"/>
-      <stop offset="1" stop-color="#1A9FFF"/>
-    </linearGradient>
-  </defs>
+  <circle cx="28.5929" cy="57.5001" r="28.5929" fill="black"/>
 </svg>


### PR DESCRIPTION
All other compositor icons are also monochromatic.

---

For https://github.com/vially/wayland-explorer/pull/49#discussion_r1429153749
