### PR TITLE
Remove `linux-dmabuf-unstable-v1`, with redirect to `linux-dmabuf-v1`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,8 +15,8 @@
   to = "/protocols/kde-zkde-screencast-unstable-v1"
 
 [[redirects]]
-  from = "protocols/linux-dmabuf-unstable-v1"
-  to = "protocols/linux-dmabuf-v1"
+  from = "/protocols/linux-dmabuf-unstable-v1"
+  to = "/protocols/linux-dmabuf-v1"
 
 [[redirects]]
   from = "/protocols/wayland-protocols/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,10 @@
   to = "/protocols/kde-zkde-screencast-unstable-v1"
 
 [[redirects]]
+  from = "protocols/linux-dmabuf-unstable-v1"
+  to = "protocols/linux-dmabuf-v1"
+
+[[redirects]]
   from = "/protocols/wayland-protocols/*"
   to = "/protocols/wayland-protocols-gitlab.html"
   status = 200

--- a/src/data/protocol-registry.ts
+++ b/src/data/protocol-registry.ts
@@ -172,13 +172,6 @@ const protocols: WaylandProtocolRegistryItem[] = [
         protocol: require('./protocols/keyboard-shortcuts-inhibit-unstable-v1.json'),
     },
     {
-        id: 'linux-dmabuf-unstable-v1',
-        name: 'Linux DMA-BUF',
-        source: WaylandProtocolSource.WaylandProtocols,
-        stability: WaylandProtocolStability.Unstable,
-        protocol: require('./protocols/linux-dmabuf-unstable-v1.json'),
-    },
-    {
         id: 'linux-explicit-synchronization-unstable-v1',
         name: 'Linux explicit synchronization (dma-fence)',
         source: WaylandProtocolSource.WaylandProtocols,


### PR DESCRIPTION
This is now a duplicate of the stable `linux-dmabuf-v1`, but (maybe?) won't be updated in the future for protocol changes. It defines the exact same interfaces with the exact same names. So there's no reason to have both.

I think the redirect here should be correct, though I don't know if that can be tested locally.