### PR TITLE
Deprecation hints

### DIFF
--- a/src/components/WaylandEnum.tsx
+++ b/src/components/WaylandEnum.tsx
@@ -26,7 +26,7 @@ export const WaylandEnum: React.FC<
                 </span>
             </a>
             {(element.bitfield || element.since) && (
-                <div className="flex items-center">
+                <div className="flex items-center gap-1">
                     {element.bitfield && (
                         <Badge
                             bgColor="bg-orange-100"

--- a/src/components/WaylandEvent.tsx
+++ b/src/components/WaylandEvent.tsx
@@ -26,7 +26,7 @@ export const WaylandEvent: React.FC<
                 </span>
             </a>
             {(element.eventType || element.since) && (
-                <div className="flex items-center">
+                <div className="flex items-center gap-1">
                     {element.eventType && (
                         <Badge bgColor="bg-pink-100" textColor="text-pink-800">
                             Type: {element.eventType}

--- a/src/components/WaylandInterface.tsx
+++ b/src/components/WaylandInterface.tsx
@@ -1,3 +1,4 @@
+import { WaylandDeprecationItem } from '../model/wayland-protocol-metadata'
 import { WaylandElementProps, WaylandInterfaceModel } from './common'
 import { WaylandColorTheme as colors } from './common/wayland-protocol-icons'
 import { Badge } from './content/Badge'
@@ -7,8 +8,10 @@ import { WaylandEvent } from './WaylandEvent'
 import { WaylandRequest } from './WaylandRequest'
 
 export const WaylandInterface: React.FC<
-    WaylandElementProps<WaylandInterfaceModel>
-> = ({ element }) => (
+    WaylandElementProps<WaylandInterfaceModel> & {
+        deprecated?: WaylandDeprecationItem
+    }
+> = ({ element, deprecated }) => (
     <div>
         <div className="flex items-center flex-wrap justify-between">
             <h2
@@ -25,7 +28,21 @@ export const WaylandInterface: React.FC<
                 </a>
             </h2>
 
-            <Badge>version {element.version}</Badge>
+            <div className="flex items-center gap-1">
+                {deprecated ? (
+                    <Badge
+                        bgColor="bg-red-500"
+                        textColor="text-white"
+                        fontWeigth="font-bold"
+                        title={deprecated.reason}
+                    >
+                        Deprecated
+                    </Badge>
+                ) : (
+                    <></>
+                )}
+                <Badge>version {element.version}</Badge>
+            </div>
         </div>
 
         {element.description ? (

--- a/src/components/WaylandProtocol.tsx
+++ b/src/components/WaylandProtocol.tsx
@@ -13,6 +13,11 @@ export const WaylandProtocol: React.FC<{
 }> = ({ element, metadata }) => {
     usePageTitle(`${metadata.name} protocol`)
 
+    const get_deprecation = (name: string) => {
+        const deprecated = metadata.deprecated ? metadata.deprecated : []
+        return deprecated.find((item) => item.name === name)
+    }
+
     return (
         <div>
             <div className="py-4 border-b border-gray-200 mb-10 dark:border-gray-700">
@@ -32,7 +37,10 @@ export const WaylandProtocol: React.FC<{
             </div>
             {element.interfaces.map((childElement, index) => (
                 <div key={index}>
-                    <WaylandInterface element={childElement} />
+                    <WaylandInterface
+                        element={childElement}
+                        deprecated={get_deprecation(childElement.name)}
+                    />
                     <hr className="my-10" />
                 </div>
             ))}

--- a/src/components/WaylandRequest.tsx
+++ b/src/components/WaylandRequest.tsx
@@ -25,7 +25,7 @@ export const WaylandRequest: React.FC<
                 </span>
             </a>
             {(element.requestType || element.since) && (
-                <div className="flex items-center">
+                <div className="flex items-center gap-1">
                     {element.requestType && (
                         <Badge bgColor="bg-pink-100" textColor="text-pink-800">
                             Type: {element.requestType}

--- a/src/components/content/Badge.tsx
+++ b/src/components/content/Badge.tsx
@@ -1,12 +1,15 @@
 export const Badge: React.FC<{
     bgColor?: string
     textColor?: string
+    fontWeigth?: string
+    title?: string
     children?: React.ReactNode
-}> = ({ children, bgColor, textColor }) => (
+}> = ({ children, bgColor, textColor, fontWeigth, title }) => (
     <span
-        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-            bgColor || 'bg-gray-100'
-        } ${textColor || 'text-gray-800'}`}
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs  ${
+            fontWeigth || 'font-medium'
+        } ${bgColor || 'bg-gray-100'} ${textColor || 'text-gray-800'}`}
+        title={title}
     >
         {children}
     </span>

--- a/src/data/protocol-registry.ts
+++ b/src/data/protocol-registry.ts
@@ -16,6 +16,10 @@ const protocols: WaylandProtocolRegistryItem[] = [
         source: WaylandProtocolSource.WaylandCore,
         stability: WaylandProtocolStability.Stable,
         protocol: require('./protocols/wayland.json'),
+        deprecated: [
+            { name: 'wl_shell', reason: 'Use xdg-shell' },
+            { name: 'wl_shell_surface', reason: 'Use xdg-shell' },
+        ],
     },
     {
         id: 'presentation-time',
@@ -366,6 +370,10 @@ const protocols: WaylandProtocolRegistryItem[] = [
         source: WaylandProtocolSource.KDEProtocols,
         stability: WaylandProtocolStability.Unstable,
         protocol: require('./protocols/kde-idle.json'),
+        deprecated: [
+            { name: 'org_kde_kwin_idle', reason: 'Use ext-idle-notify' },
+            { name: 'org_kde_kwin_idle_timeout', reason: 'Use ext-idle-notify' },
+        ],
     },
     {
         id: 'kde-keystate',
@@ -457,6 +465,16 @@ const protocols: WaylandProtocolRegistryItem[] = [
         source: WaylandProtocolSource.KDEProtocols,
         stability: WaylandProtocolStability.Unstable,
         protocol: require('./protocols/kde-server-decoration.json'),
+        deprecated: [
+            {
+                name: 'org_kde_kwin_server_decoration_manager',
+                reason: 'Use xdg-decoration',
+            },
+            {
+                name: 'org_kde_kwin_server_decoration',
+                reason: 'Use xdg-decoration',
+            },
+        ],
     },
     {
         id: 'kde-server-decoration-palette',

--- a/src/model/wayland-protocol-metadata.ts
+++ b/src/model/wayland-protocol-metadata.ts
@@ -13,10 +13,16 @@ export enum WaylandProtocolSource {
     External = 'external',
 }
 
+export interface WaylandDeprecationItem {
+    name: string
+    reason: string
+}
+
 export interface WaylandProtocolMetadata {
     id: string
     name: string
     source: WaylandProtocolSource
     stability: WaylandProtocolStability
     externalUrl?: string
+    deprecated?: WaylandDeprecationItem[]
 }


### PR DESCRIPTION
Pretty self-explanatory I suppose:
![image](https://github.com/vially/wayland-explorer/assets/20758186/8155f9c0-a34c-40e9-a00e-09cc62473a5a)
![image](https://github.com/vially/wayland-explorer/assets/20758186/5857d0cf-573c-4da2-bb33-d6ff157b45cd)

---

Would be cool to have this directly in xml files, but for now this should do fine I guess.