### PR TITLE
Regenerate `gamescope` compositor info on version `3.14.3`

### DIFF
--- a/src/data/compositors/gamescope.json
+++ b/src/data/compositors/gamescope.json
@@ -3,23 +3,15 @@
   "version": "3.14.3",
   "globals": [
     {
-      "interface": "wl_shm",
-      "version": 1
-    },
-    {
-      "interface": "zwp_linux_dmabuf_v1",
-      "version": 4
-    },
-    {
-      "interface": "wl_compositor",
-      "version": 5
+      "interface": "gamescope_control",
+      "version": 3
     },
     {
       "interface": "gamescope_input_method_manager",
       "version": 3
     },
     {
-      "interface": "gamescope_xwayland",
+      "interface": "gamescope_pipewire",
       "version": 1
     },
     {
@@ -27,27 +19,35 @@
       "version": 1
     },
     {
-      "interface": "gamescope_pipewire",
+      "interface": "gamescope_xwayland",
       "version": 1
     },
     {
-      "interface": "gamescope_control",
-      "version": 3
-    },
-    {
-      "interface": "wp_presentation",
-      "version": 1
+      "interface": "wl_compositor",
+      "version": 5
     },
     {
       "interface": "wl_drm",
       "version": 2
     },
     {
+      "interface": "wl_output",
+      "version": 4
+    },
+    {
+      "interface": "wl_seat",
+      "version": 9
+    },
+    {
+      "interface": "wl_shm",
+      "version": 1
+    },
+    {
       "interface": "wp_linux_drm_syncobj_manager_v1",
       "version": 1
     },
     {
-      "interface": "zwp_relative_pointer_manager_v1",
+      "interface": "wp_presentation",
       "version": 1
     },
     {
@@ -55,12 +55,12 @@
       "version": 3
     },
     {
-      "interface": "wl_seat",
-      "version": 9
+      "interface": "zwp_linux_dmabuf_v1",
+      "version": 4
     },
     {
-      "interface": "wl_output",
-      "version": 4
+      "interface": "zwp_relative_pointer_manager_v1",
+      "version": 1
     }
   ]
 }

--- a/src/data/compositors/gamescope.json
+++ b/src/data/compositors/gamescope.json
@@ -1,14 +1,10 @@
 {
-  "generationTimestamp": 1702565286938,
-  "version": null,
+  "generationTimestamp": 1712860380305,
+  "version": "3.14.3",
   "globals": [
     {
       "interface": "wl_shm",
       "version": 1
-    },
-    {
-      "interface": "wl_drm",
-      "version": 2
     },
     {
       "interface": "zwp_linux_dmabuf_v1",
@@ -20,14 +16,14 @@
     },
     {
       "interface": "gamescope_input_method_manager",
-      "version": 2
+      "version": 3
     },
     {
       "interface": "gamescope_xwayland",
       "version": 1
     },
     {
-      "interface": "gamescope_swapchain_factory",
+      "interface": "gamescope_swapchain_factory_v2",
       "version": 1
     },
     {
@@ -36,18 +32,22 @@
     },
     {
       "interface": "gamescope_control",
-      "version": 2
-    },
-    {
-      "interface": "gamescope_tearing_control_v1",
-      "version": 1
+      "version": 3
     },
     {
       "interface": "wp_presentation",
       "version": 1
     },
     {
-      "interface": "gamescope_commit_queue_manager_v1",
+      "interface": "wl_drm",
+      "version": 2
+    },
+    {
+      "interface": "wp_linux_drm_syncobj_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_relative_pointer_manager_v1",
       "version": 1
     },
     {
@@ -56,7 +56,7 @@
     },
     {
       "interface": "wl_seat",
-      "version": 8
+      "version": 9
     },
     {
       "interface": "wl_output",


### PR DESCRIPTION
Note that `wp_linux_drm_syncobj_manager_v1` shows up because of running in a virtual terminal now, instead of running nested in `sway`, because `gamescope` only exposes it if the backend supports explicit sync:

https://github.com/ValveSoftware/gamescope/blob/39f2779d39720792049f1589d0d6cf31876137e9/src/wlserver.cpp#L1624-L1628

This report is generated with the latest 0.0.3 release of `wlprobe` that sorts globals before printing them, so that the order of this list is no longer changing going forward.
