### PR TITLE
Sort `sway 1.9` compositor info

### DIFF
--- a/src/data/compositors/sway.json
+++ b/src/data/compositors/sway.json
@@ -1,57 +1,13 @@
 {
-  "generationTimestamp": 1709750464116,
+  "generationTimestamp": 1712862395247,
   "version": "1.9",
   "globals": [
-    {
-      "interface": "wl_shm",
-      "version": 1
-    },
-    {
-      "interface": "wl_drm",
-      "version": 2
-    },
-    {
-      "interface": "zwp_linux_dmabuf_v1",
-      "version": 4
-    },
-    {
-      "interface": "wl_compositor",
-      "version": 6
-    },
-    {
-      "interface": "wl_subcompositor",
-      "version": 1
-    },
-    {
-      "interface": "wl_data_device_manager",
-      "version": 3
-    },
-    {
-      "interface": "zwlr_gamma_control_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "zxdg_output_manager_v1",
-      "version": 3
-    },
     {
       "interface": "ext_idle_notifier_v1",
       "version": 1
     },
     {
-      "interface": "zwp_idle_inhibit_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "zwlr_layer_shell_v1",
-      "version": 4
-    },
-    {
-      "interface": "xdg_wm_base",
-      "version": 2
-    },
-    {
-      "interface": "zwp_tablet_manager_v2",
+      "interface": "ext_session_lock_manager_v1",
       "version": 1
     },
     {
@@ -59,20 +15,96 @@
       "version": 1
     },
     {
-      "interface": "zxdg_decoration_manager_v1",
+      "interface": "wl_compositor",
+      "version": 6
+    },
+    {
+      "interface": "wl_data_device_manager",
+      "version": 3
+    },
+    {
+      "interface": "wl_drm",
+      "version": 2
+    },
+    {
+      "interface": "wl_output",
+      "version": 4
+    },
+    {
+      "interface": "wl_seat",
+      "version": 8
+    },
+    {
+      "interface": "wl_shm",
       "version": 1
     },
     {
-      "interface": "zwp_relative_pointer_manager_v1",
+      "interface": "wl_subcompositor",
       "version": 1
     },
     {
-      "interface": "zwp_pointer_constraints_v1",
+      "interface": "wp_content_type_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_cursor_shape_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_drm_lease_device_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_fractional_scale_manager_v1",
       "version": 1
     },
     {
       "interface": "wp_presentation",
       "version": 1
+    },
+    {
+      "interface": "wp_security_context_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_single_pixel_buffer_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_viewporter",
+      "version": 1
+    },
+    {
+      "interface": "xdg_activation_v1",
+      "version": 1
+    },
+    {
+      "interface": "xdg_wm_base",
+      "version": 2
+    },
+    {
+      "interface": "zwlr_data_control_manager_v1",
+      "version": 2
+    },
+    {
+      "interface": "zwlr_export_dmabuf_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwlr_foreign_toplevel_manager_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwlr_gamma_control_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwlr_input_inhibit_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwlr_layer_shell_v1",
+      "version": 4
     },
     {
       "interface": "zwlr_output_manager_v1",
@@ -83,91 +115,19 @@
       "version": 1
     },
     {
-      "interface": "zwp_input_method_manager_v2",
-      "version": 1
-    },
-    {
-      "interface": "zwp_text_input_manager_v3",
-      "version": 1
-    },
-    {
-      "interface": "zwlr_foreign_toplevel_manager_v1",
-      "version": 3
-    },
-    {
-      "interface": "ext_session_lock_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "wp_drm_lease_device_v1",
-      "version": 1
-    },
-    {
-      "interface": "zwlr_export_dmabuf_manager_v1",
-      "version": 1
-    },
-    {
       "interface": "zwlr_screencopy_manager_v1",
       "version": 3
-    },
-    {
-      "interface": "zwlr_data_control_manager_v1",
-      "version": 2
-    },
-    {
-      "interface": "wp_security_context_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "wp_viewporter",
-      "version": 1
-    },
-    {
-      "interface": "wp_single_pixel_buffer_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "wp_content_type_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "wp_fractional_scale_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "zxdg_exporter_v1",
-      "version": 1
-    },
-    {
-      "interface": "zxdg_importer_v1",
-      "version": 1
-    },
-    {
-      "interface": "zxdg_exporter_v2",
-      "version": 1
-    },
-    {
-      "interface": "zxdg_importer_v2",
-      "version": 1
-    },
-    {
-      "interface": "xdg_activation_v1",
-      "version": 1
-    },
-    {
-      "interface": "wp_cursor_shape_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "zwp_virtual_keyboard_manager_v1",
-      "version": 1
     },
     {
       "interface": "zwlr_virtual_pointer_manager_v1",
       "version": 2
     },
     {
-      "interface": "zwlr_input_inhibit_manager_v1",
+      "interface": "zwp_idle_inhibit_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_input_method_manager_v2",
       "version": 1
     },
     {
@@ -175,20 +135,60 @@
       "version": 1
     },
     {
-      "interface": "zwp_pointer_gestures_v1",
-      "version": 3
+      "interface": "zwp_linux_dmabuf_v1",
+      "version": 4
     },
     {
-      "interface": "wl_seat",
-      "version": 8
+      "interface": "zwp_pointer_constraints_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_pointer_gestures_v1",
+      "version": 3
     },
     {
       "interface": "zwp_primary_selection_device_manager_v1",
       "version": 1
     },
     {
-      "interface": "wl_output",
-      "version": 4
+      "interface": "zwp_relative_pointer_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_tablet_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_text_input_manager_v3",
+      "version": 1
+    },
+    {
+      "interface": "zwp_virtual_keyboard_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_decoration_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_exporter_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_exporter_v2",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_importer_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_importer_v2",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_output_manager_v1",
+      "version": 3
     }
   ]
 }


### PR DESCRIPTION
The new `wlprobe 0.0.3` emits `"globals"` in alphabetically sorted order so that they no longer move around when regenerating on newer/different versions of compositors, generating unnecessary and especially unreadable noise in diffs.
