### PR TITLE
Update compositor data for Mir 2.16

### DIFF
--- a/src/data/compositors/mir.json
+++ b/src/data/compositors/mir.json
@@ -1,6 +1,6 @@
 {
-  "generationTimestamp": 1690029459060,
-  "version": null,
+  "generationTimestamp": 1713448515430,
+  "version": "2.16",
   "globals": [
     {
       "interface": "ext_session_lock_manager_v1",
@@ -64,6 +64,14 @@
     },
     {
       "interface": "zwp_input_method_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_input_method_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_input_panel_v1",
       "version": 1
     },
     {

--- a/src/data/compositors/mir.json
+++ b/src/data/compositors/mir.json
@@ -3,31 +3,39 @@
   "version": null,
   "globals": [
     {
-      "interface": "zwp_linux_dmabuf_v1",
-      "version": 3
+      "interface": "ext_session_lock_manager_v1",
+      "version": 1
     },
     {
       "interface": "wl_compositor",
       "version": 4
     },
     {
-      "interface": "wl_subcompositor",
-      "version": 1
+      "interface": "wl_data_device_manager",
+      "version": 3
+    },
+    {
+      "interface": "wl_drm",
+      "version": 2
+    },
+    {
+      "interface": "wl_output",
+      "version": 4
     },
     {
       "interface": "wl_seat",
       "version": 8
     },
     {
-      "interface": "wl_data_device_manager",
-      "version": 3
-    },
-    {
       "interface": "wl_shell",
       "version": 1
     },
     {
-      "interface": "zxdg_shell_v6",
+      "interface": "wl_shm",
+      "version": 1
+    },
+    {
+      "interface": "wl_subcompositor",
       "version": 1
     },
     {
@@ -35,32 +43,44 @@
       "version": 5
     },
     {
-      "interface": "zwlr_layer_shell_v1",
-      "version": 4
-    },
-    {
-      "interface": "zxdg_output_manager_v1",
-      "version": 3
-    },
-    {
       "interface": "zwlr_foreign_toplevel_manager_v1",
       "version": 2
     },
     {
-      "interface": "zwp_relative_pointer_manager_v1",
+      "interface": "zwlr_layer_shell_v1",
+      "version": 4
+    },
+    {
+      "interface": "zwlr_screencopy_manager_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwlr_virtual_pointer_manager_v1",
+      "version": 2
+    },
+    {
+      "interface": "zwp_idle_inhibit_manager_v1",
       "version": 1
+    },
+    {
+      "interface": "zwp_input_method_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_linux_dmabuf_v1",
+      "version": 3
     },
     {
       "interface": "zwp_pointer_constraints_v1",
       "version": 1
     },
     {
-      "interface": "zwp_virtual_keyboard_manager_v1",
+      "interface": "zwp_primary_selection_device_manager_v1",
       "version": 1
     },
     {
-      "interface": "zwlr_virtual_pointer_manager_v1",
-      "version": 2
+      "interface": "zwp_relative_pointer_manager_v1",
+      "version": 1
     },
     {
       "interface": "zwp_text_input_manager_v1",
@@ -75,32 +95,16 @@
       "version": 1
     },
     {
-      "interface": "zwp_input_method_manager_v2",
+      "interface": "zwp_virtual_keyboard_manager_v1",
       "version": 1
     },
     {
-      "interface": "zwp_idle_inhibit_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "zwlr_screencopy_manager_v1",
+      "interface": "zxdg_output_manager_v1",
       "version": 3
     },
     {
-      "interface": "zwp_primary_selection_device_manager_v1",
+      "interface": "zxdg_shell_v6",
       "version": 1
-    },
-    {
-      "interface": "ext_session_lock_manager_v1",
-      "version": 1
-    },
-    {
-      "interface": "wl_shm",
-      "version": 1
-    },
-    {
-      "interface": "wl_output",
-      "version": 4
     }
   ]
 }


### PR DESCRIPTION
according to https://github.com/canonical/mir/pull/3000 Mir now supports both zwp_input_method_v1 and zwp_input_panel_v1

this is included in Mir 2.16: https://github.com/canonical/mir/releases/tag/v2.16.0