### PR TITLE
Handle table overflow in mobile layout

### DIFF
--- a/src/components/WaylandDataTable.tsx
+++ b/src/components/WaylandDataTable.tsx
@@ -16,7 +16,7 @@ export const WaylandDataTable: React.FC<{
     interfaceName: string
     parentElement: WaylandRequestModel | WaylandEventModel | WaylandEnumModel
 }> = ({ elements, interfaceName, parentElement }) => (
-    <div className="my-4 border-b border-gray-200 dark:border-gray-700">
+    <div className="my-4 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
         <table className="w-full table-auto text-left border-collapse">
             <thead>
                 <tr>


### PR DESCRIPTION
Adds x scroll behavior to tables, effectively fixing the layout overflowing out of the page on mobile

Before:
![image](https://github.com/vially/wayland-explorer/assets/20758186/0d24b8ee-61a9-4a9f-aa96-f35b651e53b3)

After:
![image](https://github.com/vially/wayland-explorer/assets/20758186/3f9b1283-565c-4fc8-a037-04d702d7881c)
