### PR TITLE
Shorten compositor versions to exclude maintenance releases

### DIFF
--- a/src/data/compositors/kwin.json
+++ b/src/data/compositors/kwin.json
@@ -1,6 +1,6 @@
 {
   "generationTimestamp": 1713535641090,
-  "version": "6.0.4",
+  "version": "6.0",
   "globals": [
     {
       "interface": "ext_idle_notifier_v1",

--- a/src/data/compositors/mutter.json
+++ b/src/data/compositors/mutter.json
@@ -1,6 +1,6 @@
 {
   "generationTimestamp": 1709750464116,
-  "version": "46.1",
+  "version": "46",
   "globals": [
     {
       "interface": "wl_compositor",


### PR DESCRIPTION
These are very unlikely to make any difference to the set of implemented wayland protocols detected by wlprobe.

As I originally noted in https://github.com/vially/wayland-explorer/pull/64#issuecomment-2112986080 I'm unsure if GameScope is stable in this regard compared to Mutter or KWin.