### PR TITLE
Recolor support matrix and Fix outline clipped on top 

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -45,7 +45,7 @@ export const WaylandCompositors: React.FC<{
                                     className="border-b border-gray-300 dark:border-gray-900 p-2"
                                 >
                                     <div className="flex justify-center">
-                                        <div className="w-7 h-7 leading-7 bg-emerald-500 text-white rounded-lg text-center">
+                                        <div className="w-7 h-7 leading-7 bg-emerald-700 text-white rounded-lg text-center">
                                             {version}
                                         </div>
                                     </div>
@@ -58,7 +58,7 @@ export const WaylandCompositors: React.FC<{
                                     className="border-b border-gray-300 dark:border-gray-900 p-2"
                                 >
                                     <div className="flex justify-center">
-                                        <div className="w-7 h-7 leading-7 bg-gray-900 text-white rounded-lg text-center">
+                                        <div className="w-7 h-7 leading-7 bg-red-900 text-white rounded-lg text-center">
                                             x
                                         </div>
                                     </div>

--- a/src/components/layout/MultiColumnLayout.tsx
+++ b/src/components/layout/MultiColumnLayout.tsx
@@ -66,7 +66,7 @@ export const MultiColumnLayout: React.FC<{
                 </main>
                 {outlineView && (
                     <aside className="hidden lg:block lg:col-span-3 xl:col-span-2">
-                        <div className="sticky max-h-screen top-0 space-y-4 overflow-y-auto py-4 scrollbar-thin scrollbar-thumb-rounded scrollbar-thumb-gray-200 dark:scrollbar-thumb-gray-700">
+                        <div className="sticky max-h-screen top-16 xl:top-0 space-y-4 overflow-y-auto py-4 scrollbar-thin scrollbar-thumb-rounded scrollbar-thumb-gray-200 dark:scrollbar-thumb-gray-700">
                             <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
                                 Outline
                             </h2>


### PR DESCRIPTION
This includes the color changes I talked about and an unrelated minor fix.

Previously the top `4em` of the outline sticky container were clipped when you scroll down past the navbar in the page. It only hide the "Outline" header in terms of content, but for scrollbar styles that have buttons on the top and bottom to scroll, it hid the top one which was pretty bad:

![image](https://github.com/user-attachments/assets/f1640900-a063-482e-8c6f-44f142f5050e)

Hardcoding `top-16 xl:top-0` to the headers size and media query feels a little wrong but it's small enough that it's probably fine, you pretty much have to either hardcore it or use a variable to get this to work (e.g. see MDN), and that felt excessive here.

I also tried to improve the way `since` badges look in enum variants:
![image](https://github.com/user-attachments/assets/9dfee293-98e1-42f3-844b-57cea8a9eee3)
But I don't exactly have an idea how they should look and the table display modes are pretty weird, so I didn't end up changing anything there.