### PR TITLE
Add niri compositor data (and make icons optional)

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -128,11 +128,13 @@ const CanIUseTable: React.FC<{
                                 <div className="[writing-mode:vertical-rl] rotate-180">
                                     {comp.name}
                                 </div>
-                                <img
-                                    alt={comp.name}
-                                    src={`logos/${comp.icon}.svg`}
-                                    className="w-5 dark:invert"
-                                />
+                                {comp.icon && (
+                                    <img
+                                        alt={comp.name}
+                                        src={`logos/${comp.icon}.svg`}
+                                        className="w-5 dark:invert"
+                                    />
+                                )}
                             </div>
                             <SubTitle compositor={comp} />
                         </th>

--- a/src/data/compositor-registry.ts
+++ b/src/data/compositor-registry.ts
@@ -12,7 +12,7 @@ export interface CompositorInfo {
 export interface CompositorRegistryItem {
     id: string
     name: string
-    icon: string
+    icon?: string
     info: CompositorInfo
 }
 
@@ -46,6 +46,11 @@ export const compositorRegistry: CompositorRegistryItem[] = [
         name: 'Hyprland',
         icon: 'hyprland',
         info: require('./compositors/hyprland.json'),
+    },
+    {
+        id: 'niri',
+        name: 'niri',
+        info: require('./compositors/niri.json'),
     },
     {
         id: 'weston',

--- a/src/data/compositors/niri.json
+++ b/src/data/compositors/niri.json
@@ -1,0 +1,158 @@
+{
+  "generationTimestamp": 1724804860208,
+  "version": "0.1.8",
+  "globals": [
+    {
+      "interface": "ext_idle_notifier_v1",
+      "version": 1
+    },
+    {
+      "interface": "ext_session_lock_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wl_compositor",
+      "version": 6
+    },
+    {
+      "interface": "wl_data_device_manager",
+      "version": 3
+    },
+    {
+      "interface": "wl_drm",
+      "version": 2
+    },
+    {
+      "interface": "wl_eglstream_display",
+      "version": 1
+    },
+    {
+      "interface": "wl_output",
+      "version": 4
+    },
+    {
+      "interface": "wl_output",
+      "version": 4
+    },
+    {
+      "interface": "wl_seat",
+      "version": 9
+    },
+    {
+      "interface": "wl_shm",
+      "version": 1
+    },
+    {
+      "interface": "wl_subcompositor",
+      "version": 1
+    },
+    {
+      "interface": "wp_cursor_shape_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_drm_lease_device_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_fractional_scale_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_presentation",
+      "version": 1
+    },
+    {
+      "interface": "wp_security_context_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_viewporter",
+      "version": 1
+    },
+    {
+      "interface": "xdg_activation_v1",
+      "version": 1
+    },
+    {
+      "interface": "xdg_wm_base",
+      "version": 6
+    },
+    {
+      "interface": "zwlr_data_control_manager_v1",
+      "version": 2
+    },
+    {
+      "interface": "zwlr_foreign_toplevel_manager_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwlr_gamma_control_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwlr_layer_shell_v1",
+      "version": 4
+    },
+    {
+      "interface": "zwlr_output_manager_v1",
+      "version": 4
+    },
+    {
+      "interface": "zwlr_screencopy_manager_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwp_idle_inhibit_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_input_method_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_linux_dmabuf_v1",
+      "version": 5
+    },
+    {
+      "interface": "zwp_pointer_constraints_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_pointer_gestures_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwp_primary_selection_device_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_relative_pointer_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_tablet_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_text_input_manager_v3",
+      "version": 1
+    },
+    {
+      "interface": "zwp_virtual_keyboard_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_exporter_v2",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_importer_v2",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_output_manager_v1",
+      "version": 3
+    }
+  ]
+}


### PR DESCRIPTION
Niri currently does not have a logo so I made them optional.

Again I'm not sure about compositor order, I have no malicious intent towards any compositor, I tried to keep compositors people daily drive before specialised compositors, and also thought it made since to cosmic next to other "big" desktop environments, so I put cosmic before hyprland, and niri after as it's newer and currently has a smaller userbase.