### PR TITLE
Display breadcrumbs on mobile

### DIFF
--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -20,8 +20,8 @@ export const Breadcrumbs: React.FC<{ metadata: WaylandProtocolMetadata }> = ({
 
     return (
         <div>
-            <nav className="hidden sm:flex" aria-label="Breadcrumb">
-                <ol className="flex items-center space-x-2">
+            <nav aria-label="Breadcrumb">
+                <ol className="flex flex-wrap items-center space-x-1 [&>li]:overflow-x-hidden">
                     <li>
                         <div>
                             {metadata.source !==
@@ -32,7 +32,7 @@ export const Breadcrumbs: React.FC<{ metadata: WaylandProtocolMetadata }> = ({
                                     )}
                                     target="_blank"
                                     rel="noreferrer"
-                                    className="text-sm text-gray-500 hover:text-gray-700"
+                                    className="text-sm/loose text-gray-500 hover:text-gray-700"
                                 >
                                     {metadata.source}
                                 </a>
@@ -67,7 +67,7 @@ export const Breadcrumbs: React.FC<{ metadata: WaylandProtocolMetadata }> = ({
                                         )}
                                         target="_blank"
                                         rel="noreferrer"
-                                        className="ml-2 text-sm font-medium text-gray-500 hover:text-gray-700"
+                                        className="ml-1 text-sm/loose font-medium text-gray-500 hover:text-gray-700"
                                     >
                                         {metadata.stability}
                                     </a>
@@ -95,7 +95,7 @@ export const Breadcrumbs: React.FC<{ metadata: WaylandProtocolMetadata }> = ({
                                 href={urlForWaylandProtocol(metadata)}
                                 target="_blank"
                                 rel="noreferrer"
-                                className="ml-2 text-sm font-medium text-gray-500 hover:text-gray-700 truncate"
+                                className="ml-1 text-sm font-medium text-gray-500 hover:text-gray-700 truncate"
                             >
                                 {xmlFileBaseName}.xml
                             </a>
@@ -103,11 +103,6 @@ export const Breadcrumbs: React.FC<{ metadata: WaylandProtocolMetadata }> = ({
                     </li>
                 </ol>
             </nav>
-            <div className="sm:hidden">
-                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                    {metadata.id}
-                </span>
-            </div>
         </div>
     )
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e53234d9-813b-4ec3-8f42-62f4cc122e1c)
![image](https://github.com/user-attachments/assets/1c72cf6f-bd4e-4686-9f7a-c258cd4ffd91)

Extremely narrow case (`300px * 700px`):

![image](https://github.com/user-attachments/assets/b845c4c7-3cf5-42fa-ba1b-b0d3eb434364)

Also slightly shrinks the margin around the seperators, they were really far before and it also helps with some edge cases to fit more text on mobile layout:

![image](https://github.com/user-attachments/assets/57a92582-2e2c-48d5-bf2f-be3c837ffac8)


Fixes #71.