### PR TITLE
Align compositor icon/names in protocol support grid

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -128,13 +128,13 @@ const CanIUseTable: React.FC<{
                                 <div className="[writing-mode:vertical-rl] rotate-180">
                                     {comp.name}
                                 </div>
-                                {comp.icon && (
-                                    <img
+                                <div className="aspect-square h-5">
+                                    {comp.icon && <img
                                         alt={comp.name}
                                         src={`logos/${comp.icon}.svg`}
-                                        className="w-5 dark:invert"
-                                    />
-                                )}
+                                        className="dark:invert h-5 m-auto"
+                                    />}
+                                </div>
                             </div>
                             <SubTitle compositor={comp} />
                         </th>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/18201471-b8f0-404c-8516-5d0749bb62c9)
After:
![image](https://github.com/user-attachments/assets/360589c8-0d1f-4480-940c-ed5df13e823d)
