### PR TITLE
Fix yet another layout overflow

### DIFF
--- a/src/components/WaylandEnum.tsx
+++ b/src/components/WaylandEnum.tsx
@@ -10,7 +10,7 @@ export const WaylandEnum: React.FC<
     WaylandElementProps<WaylandEnumModel> & { interfaceName: string }
 > = ({ element, interfaceName }) => (
     <div>
-        <div className="flex items-center flex-wrap justify-between">
+        <div className="flex items-center flex-wrap justify-between overflow-x-auto">
             <a
                 id={`${interfaceName}:${element.type}:${element.name}`}
                 href={`#${interfaceName}:${element.type}:${element.name}`}


### PR DESCRIPTION
Adding horizontal scroll to a title is not a pinnacle of UI design, but this will at least fix the layout overflowing yet again on mobile.

(example of this title overflowing the layout can be found in: https://wayland.app/protocols/cosmic-toplevel-management-unstable-v1)