### PR TITLE
Gitlab MR list page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,13 @@ import { WaylandProtocol } from './components/WaylandProtocol'
 import { waylandProtocolRegistry } from './data/protocol-registry'
 import { NotFound } from './pages/404'
 import { Homepage } from './pages/Homepage'
-import { GitLab } from './pages/GitLab'
+import { GitLab, GitLabMrList } from './pages/GitLab'
 
 function App() {
     let contentView = <Homepage />
     let outlineView = null
 
+    const [isGitlabMrList] = useRoute<{ iid: string }>('/wayland-protocols')
     const [isGitlab, gitlabParams] = useRoute<{ iid: string }>('/wayland-protocols/:iid')
 
     const [match, params] = useRoute<{ protocolId: string }>('/:protocolId')
@@ -19,7 +20,9 @@ function App() {
 
     useAnalytics().trackPageview()
 
-    if (isGitlab && gitlabParams?.iid) {
+    if (isGitlabMrList) {
+        return <GitLabMrList />
+    } else if (isGitlab && gitlabParams?.iid) {
         return <GitLab iid={gitlabParams?.iid}></GitLab>
     } else if (match && params?.protocolId) {
         const protocolWithMetadata = match

--- a/src/components/WaylandProtocol.tsx
+++ b/src/components/WaylandProtocol.tsx
@@ -1,5 +1,5 @@
 import { WaylandProtocolMetadata } from '../model/wayland-protocol-metadata'
-import { Breadcrumbs } from './breadcrumbs/Breadcrumbs'
+import { WaylandBreadcrumbs } from './breadcrumbs/Breadcrumbs'
 import { WaylandProtocolModel } from './common'
 import { usePageTitle } from './common/hooks-utils'
 import { WaylandCopyright } from './WaylandCopyright'
@@ -27,7 +27,7 @@ export const WaylandProtocol: React.FC<{
                     </h1>
                 </div>
 
-                <Breadcrumbs metadata={metadata} />
+                <WaylandBreadcrumbs metadata={metadata} />
 
                 {element.description && (
                     <div className="mt-6">

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import {
     kdeProtocolsWithHardcodedPrefix,
     urlForWaylandProtocol,
@@ -9,100 +10,101 @@ import {
     WaylandProtocolSource,
 } from '../../model/wayland-protocol-metadata'
 
-export const Breadcrumbs: React.FC<{ metadata: WaylandProtocolMetadata }> = ({
-    metadata,
-}) => {
+const SolidChevronRight: React.FC<{ className: string }> = ({ className }) => {
+    // Heroicon name: solid/chevron-right
+    return (
+        <svg
+            className={`shrink-0 h-5 w-5 text-gray-400 ${className}`}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+            />
+        </svg>
+    )
+}
+
+export const BreadcrumbSection: React.FC<{
+    children?: React.ReactNode
+    href?: string
+}> = ({ children, href }) =>
+    href ? (
+        <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm font-medium text-gray-500 hover:text-gray-700 truncate"
+        >
+            {children}
+        </a>
+    ) : (
+        <span className="text-sm text-gray-500">{children}</span>
+    )
+
+export const WaylandBreadcrumbs: React.FC<{
+    metadata: WaylandProtocolMetadata
+}> = ({ metadata }) => {
     const xmlFileBaseName =
         metadata.source === WaylandProtocolSource.KDEProtocols &&
         !kdeProtocolsWithHardcodedPrefix.includes(metadata.id)
             ? metadata.id.substring(4)
             : metadata.id
 
-    return (
-        <div>
-            <nav aria-label="Breadcrumb">
-                <ol className="flex flex-wrap items-center space-x-1 [&>li]:overflow-x-hidden">
-                    <li>
-                        <div>
-                            {metadata.source !==
-                            WaylandProtocolSource.External ? (
-                                <a
-                                    href={urlForWaylandProtocolSource(
-                                        metadata.source
-                                    )}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="text-sm/loose text-gray-500 hover:text-gray-700"
-                                >
-                                    {metadata.source}
-                                </a>
-                            ) : (
-                                <span className="text-sm text-gray-500">
-                                    external
-                                </span>
-                            )}
-                        </div>
-                    </li>
-                    {metadata.source !== WaylandProtocolSource.WaylandCore &&
-                        metadata.source !== WaylandProtocolSource.External && (
-                            <li>
-                                <div className="flex items-center">
-                                    {/* Heroicon name: solid/chevron-right */}
-                                    <svg
-                                        className="shrink-0 h-5 w-5 text-gray-400"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                        aria-hidden="true"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                                            clipRule="evenodd"
-                                        />
-                                    </svg>
-                                    <a
-                                        href={urlForWaylandProtocolStability(
-                                            metadata
-                                        )}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        className="ml-1 text-sm/loose font-medium text-gray-500 hover:text-gray-700"
-                                    >
-                                        {metadata.stability}
-                                    </a>
-                                </div>
-                            </li>
-                        )}
-                    <li>
-                        <div className="flex items-center">
-                            {/* Heroicon name: solid/chevron-right */}
-                            <svg
-                                className="shrink-0 h-5 w-5 text-gray-400"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 20 20"
-                                fill="currentColor"
-                                aria-hidden="true"
-                            >
-                                <path
-                                    fillRule="evenodd"
-                                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                                    clipRule="evenodd"
-                                />
-                            </svg>
+    const source =
+        metadata.source === WaylandProtocolSource.External ? (
+            <BreadcrumbSection>external</BreadcrumbSection>
+        ) : (
+            <BreadcrumbSection
+                href={urlForWaylandProtocolSource(metadata.source)}
+            >
+                {metadata.source}
+            </BreadcrumbSection>
+        )
 
-                            <a
-                                href={urlForWaylandProtocol(metadata)}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="ml-1 text-sm font-medium text-gray-500 hover:text-gray-700 truncate"
-                            >
-                                {xmlFileBaseName}.xml
-                            </a>
-                        </div>
-                    </li>
-                </ol>
-            </nav>
-        </div>
+    const stability = metadata.source !== WaylandProtocolSource.WaylandCore &&
+        metadata.source !== WaylandProtocolSource.External && (
+            <BreadcrumbSection href={urlForWaylandProtocolStability(metadata)}>
+                {metadata.stability}
+            </BreadcrumbSection>
+        )
+
+    return (
+        <Breadcrumbs>
+            {source}
+            {stability}
+            <BreadcrumbSection href={urlForWaylandProtocol(metadata)}>
+                {xmlFileBaseName}.xml
+            </BreadcrumbSection>
+        </Breadcrumbs>
+    )
+}
+
+export const Breadcrumbs: React.FC<{ children?: React.ReactNode }> = ({
+    children,
+}) => {
+    return (
+        <nav aria-label="Breadcrumb">
+            <ol className="flex flex-wrap items-center space-x-1 [&>li]:overflow-x-hidden">
+                {React.Children.toArray(children).map((child, i) => {
+                    return (
+                        <li>
+                            {i !== 0 ? (
+                                <div className="flex items-center">
+                                    <SolidChevronRight className="mr-1" />
+                                    {child}
+                                </div>
+                            ) : (
+                                child
+                            )}
+                        </li>
+                    )
+                })}
+            </ol>
+        </nav>
     )
 }

--- a/src/components/sidebar-navigation/WaylandProtocolLinks.tsx
+++ b/src/components/sidebar-navigation/WaylandProtocolLinks.tsx
@@ -8,6 +8,21 @@ import {
 } from '../../model/wayland-protocol-metadata'
 import { SidebarNavLink } from './SidebarNavLink'
 
+const SectionTitle: React.FC<{ title: string; icon?: string }> = ({
+    title,
+    icon,
+}) => (
+    <h3
+        className="px-4 pb-2 text-xs font-semibold text-gray-700 uppercase tracking-wider truncate dark:text-gray-600"
+        title={title}
+    >
+        <div className="flex items-center">
+            {icon ? <span className={`codicon codicon-${icon} mr-1`} /> : null}
+            {title}
+        </div>
+    </h3>
+)
+
 export const WaylandProtocolLinks: React.FC = () => (
     <nav
         aria-label="Sidebar"
@@ -15,12 +30,7 @@ export const WaylandProtocolLinks: React.FC = () => (
     >
         {groupProtocolsIntoSections().map((section) => (
             <div key={section.name}>
-                <h3
-                    className="px-4 pb-2 text-xs font-semibold text-gray-700 uppercase tracking-wider truncate dark:text-gray-600"
-                    title={section.name}
-                >
-                    {section.name}
-                </h3>
+                <SectionTitle title={section.name} />
 
                 <div className="grow flex flex-col">
                     <div className="flex-1 space-y-1">
@@ -37,6 +47,21 @@ export const WaylandProtocolLinks: React.FC = () => (
                 </div>
             </div>
         ))}
+
+        <div>
+            <SectionTitle title="Merge Requests" icon="git-pull-request" />
+
+            <div className="grow flex flex-col">
+                <div className="flex-1 space-y-1">
+                    <SidebarNavLink
+                        href="/wayland-protocols"
+                        title="wayland-protocols"
+                    >
+                        wayland-protocols
+                    </SidebarNavLink>
+                </div>
+            </div>
+        </div>
     </nav>
 )
 

--- a/src/gitlab-api/index.ts
+++ b/src/gitlab-api/index.ts
@@ -1,0 +1,153 @@
+import { XMLParser } from 'fast-xml-parser'
+import {
+    WaylandElementType,
+    WaylandProtocol as WaylandProtocolModel,
+} from '../model/wayland'
+import { transformXMLElement } from '../lib/xml-protocol-transformers'
+
+export interface GitLabFile {
+    name: string
+    webPath: string
+    path: string
+    protocol: WaylandProtocolModel
+}
+
+export interface GitLabMergeRequest {
+    iid: number
+    title: string
+    diffStats: { path: string }[]
+    diffHeadSha: string
+}
+
+export interface GitLabPaginationInfo {
+    endCursor: string
+    hasNextPage: boolean
+}
+
+export interface GetMergeRequestsResponse {
+    pageInfo: GitLabPaginationInfo
+    mrs: GitLabMergeRequest[]
+}
+
+async function callGraphQl(query: string): Promise<any> {
+    const body = JSON.stringify({ query })
+    return await fetch('https://gitlab.freedesktop.org/api/graphql', {
+        method: 'post',
+        body,
+        headers: new Headers({
+            'Content-Type': 'application/json',
+            'Content-Length': body.length.toString(),
+        }),
+    })
+}
+
+function xml_filter({ path }: { path: string }) {
+    return path.endsWith('.xml')
+}
+
+export async function getMergeRequestFiles(
+    mr: GitLabMergeRequest
+): Promise<GitLabFile[]> {
+    const paths = mr.diffStats.map(({ path }) => path)
+    const response = await callGraphQl(`{
+      project(fullPath: "wayland/wayland-protocols") {
+        repository {
+          blobs(ref: "${mr.diffHeadSha}", paths: ${JSON.stringify(paths)}) {
+            nodes {
+              name
+              webPath
+              path
+              rawBlob
+            }
+          }
+        }
+      }
+    }`)
+
+    const nodes: {
+        name: string
+        webPath: string
+        path: string
+        rawBlob: string
+    }[] = (await response.json()).data.project.repository.blobs.nodes
+
+    return nodes.reduce<GitLabFile[]>((out, node) => {
+        const parser = new XMLParser({
+            ignoreAttributes: false,
+            attributeNamePrefix: '',
+        })
+        const xmlData = parser.parse(node.rawBlob)
+        const protocol = transformXMLElement<WaylandProtocolModel>(
+            xmlData['protocol'],
+            WaylandElementType.Protocol
+        )
+
+        if (protocol !== undefined) {
+            out.push({
+                name: node.name,
+                webPath: node.webPath,
+                path: node.path,
+                protocol,
+            })
+        }
+
+        return out
+    }, [])
+}
+
+export async function getMergeRequests(
+    after: string | undefined
+): Promise<GetMergeRequestsResponse> {
+    const after_arg = after ? `after: "${after}"` : ''
+    const response = await callGraphQl(`{
+      project(fullPath: "wayland/wayland-protocols") {
+        mergeRequests ( state: opened first: 20 ${after_arg} ) {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+          nodes {
+            iid
+            title
+            diffHeadSha
+            diffStats { path }
+          }
+        }
+      }
+    }`)
+
+    const json = await response.json()
+    const mergeRequests = json.data.project.mergeRequests
+    const nodes: GitLabMergeRequest[] = mergeRequests.nodes
+    const mrs = nodes
+        .map((node) => {
+            node.diffStats = node.diffStats.filter(xml_filter)
+            return node
+        })
+        .filter((node) => node.diffStats.length > 0)
+
+    return {
+        pageInfo: mergeRequests.pageInfo,
+        mrs,
+    }
+}
+
+export async function getMergeRequest(
+    iid: string
+): Promise<GitLabMergeRequest> {
+    const response = await callGraphQl(`{
+      project(fullPath: "wayland/wayland-protocols") {
+        mergeRequest ( iid: "${iid}" ) {
+          iid
+          title
+          diffHeadSha
+          diffStats { path }
+        }
+      }
+    }`)
+
+    const raw_json = await response.json()
+    const mergeRequest: GitLabMergeRequest = raw_json.data.project.mergeRequest
+    mergeRequest.diffStats = mergeRequest.diffStats.filter(xml_filter)
+    return mergeRequest
+}

--- a/src/pages/GitLab.tsx
+++ b/src/pages/GitLab.tsx
@@ -1,32 +1,213 @@
 import { MultiColumnLayout } from '../components/layout/MultiColumnLayout'
 import { WaylandProtocolOutline } from '../components/outline/WaylandProtocolOutline'
 import { WaylandProtocol } from '../components/WaylandProtocol'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
+import { Link } from 'wouter'
 import {
     WaylandProtocolSource,
     WaylandProtocolStability,
 } from '../model/wayland-protocol-metadata'
 import {
+    Breadcrumbs,
+    BreadcrumbSection,
+} from '../components/breadcrumbs/Breadcrumbs'
+import {
     getMergeRequest,
     getMergeRequestFiles,
+    getMergeRequests,
     GitLabFile,
+    GitLabMergeRequest,
+    GitLabPaginationInfo,
 } from '../gitlab-api'
 
-export const GitLab: React.FC<{ iid: string }> = ({ iid }) => {
-    const [files, setFiles] = useState<GitLabFile[] | null>(null)
+const useGitLabMrList = () => {
+    const [isLoading, setIsLoading] = useState<boolean>(false)
+    const [page, setPage] = useState<GitLabPaginationInfo | null>(null)
+    const [mrs, setMrs] = useState<GitLabMergeRequest[]>([])
+    const [error, setError] = useState<string | null>(null)
+
+    const load_more = useCallback(() => {
+        // Sanity check for double load_more call
+        if (isLoading) {
+            return
+        }
+
+        setIsLoading(true)
+        getMergeRequests(page?.endCursor)
+            .then((res) => {
+                setIsLoading(false)
+                setError(null)
+                setPage(res.pageInfo)
+                setMrs([...mrs, ...res.mrs])
+            })
+            .catch((err: Error) => {
+                setError(err.message)
+                setIsLoading(false)
+            })
+    }, [mrs, page, isLoading])
+
+    useEffect(
+        () => { load_more() },
+        // eslint-disable-next-line
+        []
+    )
+
+    return {
+        mrs,
+        error,
+        hasNextPage: page ? page.hasNextPage : false,
+        isLoading,
+        load_more,
+    }
+}
+
+const useGitLabMr = (iid: string) => {
+    const [isLoading, setIsLoading] = useState<boolean>(false)
+    const [files, setFiles] = useState<GitLabFile[]>([])
+    const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
+        let ignore = false
+
+        setIsLoading(true)
         getMergeRequest(iid)
             .then(getMergeRequestFiles)
-            .then(protocols => {
-                setFiles(protocols)
-            }).catch((_) => {
+            .then((files) => {
+                if (ignore) {
+                    return
+                }
+
+                setError(null)
+                setIsLoading(false)
+                setFiles(files)
+            })
+            .catch((e: Error) => {
+                if (ignore) {
+                    return
+                }
+
+                setError(e.message)
+                setIsLoading(false)
                 setFiles([])
             })
+
+        return () => {
+            ignore = true
+        }
     }, [iid])
 
-    const contentView = files ? (
+    return {
+        files,
+        isLoading,
+        error,
+    }
+}
+
+const LoadingPill: React.FC<{}> = () => {
+    return (
+        <div className="mt-5 flex justify-center animate-pulse">
+            <div className="rounded-lg border border-gray-300 bg-white px-6 py-3 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500 dark:bg-gray-800 dark:border-black">
+                Loading...
+            </div>
+        </div>
+    )
+}
+
+const ErrorCard: React.FC<{ error: string }> = ({ error }) => {
+    return (
+        <div
+            className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 dark:bg-stone-900"
+            role="alert"
+        >
+            <p className="font-bold">Error</p>
+            <p>{error}</p>
+        </div>
+    )
+}
+
+export const GitLabMrList: React.FC = () => {
+    const { mrs, hasNextPage, isLoading, error, load_more } = useGitLabMrList()
+
+    const contentView = (
+        <div>
+            <div className="py-4 border-b border-gray-200 mb-10 dark:border-gray-700">
+                <div className="flex items-center">
+                    <h1 className="text-3xl font-extrabold text-gray-900 tracking-tight dark:text-white">
+                        Merge requests
+                    </h1>
+                </div>
+
+                <Breadcrumbs>
+                    <BreadcrumbSection href="https://gitlab.freedesktop.org/wayland">
+                        wayland
+                    </BreadcrumbSection>
+                    <BreadcrumbSection href="https://gitlab.freedesktop.org/wayland/wayland-protocols">
+                        wayland-protocols
+                    </BreadcrumbSection>
+                </Breadcrumbs>
+            </div>
+
+            <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {mrs.map((mr) => (
+                    <div
+                        key={mr.iid}
+                        className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500 dark:bg-gray-800 dark:border-black"
+                    >
+                        <div className="w-full min-w-0">
+                            <Link href={`/wayland-protocols/${mr.iid}`}>
+                                <a
+                                    href={`/wayland-protocols/${mr.iid}`}
+                                    className="focus:outline-none"
+                                >
+                                    <span
+                                        className="absolute inset-0"
+                                        aria-hidden="true"
+                                    />
+                                    <div className="flex justify-between items-center">
+                                        <div className="text-sm font-medium text-gray-900 dark:text-white">
+                                            {mr.title}
+                                        </div>
+                                    </div>
+                                    <p className="capitalize text-sm text-gray-500 truncate mt-2">
+                                        !{mr.iid}
+                                    </p>
+                                </a>
+                            </Link>
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {!isLoading && hasNextPage ? (
+                <div className="mt-5 flex justify-center">
+                    <button
+                        className="rounded-lg border border-gray-300 bg-white px-6 py-3 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500 dark:bg-gray-800 dark:border-black"
+                        onClick={load_more}
+                    >
+                        Show Older
+                    </button>
+                </div>
+            ) : null}
+
+            {isLoading ? <LoadingPill /> : null}
+        </div>
+    )
+
+    const errorCard = error ? <ErrorCard error={error} /> : null
+
+    return (
+        <MultiColumnLayout hideSidebar={false}>
+            {errorCard}
+            {contentView}
+        </MultiColumnLayout>
+    )
+}
+
+export const GitLab: React.FC<{ iid: string }> = ({ iid }) => {
+    const { files, isLoading, error } = useGitLabMr(iid)
+
+    const contentView = !isLoading ? (
         <div>
             {files.map((file) => (
                 <div key={file.path} id={file.name}>
@@ -45,9 +226,7 @@ export const GitLab: React.FC<{ iid: string }> = ({ iid }) => {
             {files.length === 0 ? <h1 className="text-center text-2xl mt-5">Not found</h1> : null}
         </div>
     ) : (
-        <h1 className="text-center text-2xl mt-5">
-          Loading...
-        </h1>
+        <LoadingPill />
     )
 
     const outlineView = files && files.length !== 0 ? (
@@ -77,8 +256,11 @@ export const GitLab: React.FC<{ iid: string }> = ({ iid }) => {
         </div>
     ) : null
 
+    const errorCard = error && <ErrorCard error={error} />
+
     return (
         <MultiColumnLayout outlineView={outlineView} hideSidebar={false}>
+            {errorCard}
             {contentView}
         </MultiColumnLayout>
     )


### PR DESCRIPTION
This is a long overdue continuation of GitLab MR support.
Probably best reviewed per commit, as I had to do some random unrelated changes:
- https://github.com/vially/wayland-explorer/pull/87/commits/92da2c493f8f6af5cdb5d7907682d31e70fe086f Rework of breadcrumb to make them more modular and allow for reuse in git components
- https://github.com/vially/wayland-explorer/pull/87/commits/40a24db48b87223e309eea53127716e161107b0e Moving out all the GitLab API related stuff to separate file, as well as fixes and cleanup of the API calls
- https://github.com/vially/wayland-explorer/pull/87/commits/19fd24537b0770999054cb3c8f732877f8698b7d Introduction of the new MR list page, as well as better handling of error/loading states in existing GitLab viewer page
- https://github.com/vially/wayland-explorer/pull/87/commits/d6cc15d7573e92637f70d934b129a657a531e7d1 Introduces a discoverable way to find the GitLab viewer feature, in the sidebar

https://github.com/user-attachments/assets/8be01ce7-f570-47b9-b993-59b4967cb3bc

