### PR TITLE
Add XML value line trimming to all XML parsers

### DIFF
--- a/scripts/bin/convert-wayland-xml-to-json.ts
+++ b/scripts/bin/convert-wayland-xml-to-json.ts
@@ -1,4 +1,3 @@
-import { XMLParser } from 'fast-xml-parser'
 import { readFileSync, readdirSync, readlinkSync } from 'fs'
 import path from 'path'
 import { argv } from 'process'
@@ -9,29 +8,12 @@ import {
     WaylandProtocol,
     WaylandRequest,
 } from '../../src/model/wayland'
-import { transformXMLElement } from '../../src/lib/xml-protocol-transformers'
+import { transformXMLElement, xmlParser } from '../../src/lib/xml-protocol-transformers'
 import { jsonFileNameFor } from '../lib/utils'
 
 async function main(fileName: string) {
     const fileData = readFileSync(fileName, 'utf-8')
-    const parser = new XMLParser({
-        ignoreAttributes: false,
-        attributeNamePrefix: '',
-        tagValueProcessor: (
-            tagname,
-            tagValue,
-            jPath,
-            hasAttributes,
-            isLeadNode
-        ) => {
-            if (!isLeadNode || typeof tagValue !== 'string') return null
-            return tagValue
-                .split('\n')
-                .map((line) => line.trim())
-                .join('\n')
-        },
-    })
-    const xmlData = parser.parse(fileData)
+    const xmlData = xmlParser.parse(fileData)
     const protocol = transformXMLElement<WaylandProtocol>(
         xmlData['protocol'],
         WaylandElementType.Protocol

--- a/scripts/bin/regenerate-protocols-data.ts
+++ b/scripts/bin/regenerate-protocols-data.ts
@@ -1,9 +1,8 @@
-import { XMLParser } from 'fast-xml-parser'
 import { promises as fs } from 'fs'
 import path from 'path'
 import { WaylandElementType } from '../../src/model/wayland'
 import { findXMLFiles, jsonFileNameFor } from '../lib/utils'
-import { transformXMLElement } from '../../src/lib/xml-protocol-transformers'
+import { transformXMLElement, xmlParser } from '../../src/lib/xml-protocol-transformers'
 
 const relativeProtocolDirs = [
     path.join('protocols', 'libwayland', 'protocol'),
@@ -48,24 +47,7 @@ const deprecatedProtocols = [
 
 async function parseProtocolAndWriteToJSON(srcFileName: string): Promise<void> {
     const fileData = await fs.readFile(srcFileName, 'utf-8')
-    const parser = new XMLParser({
-        ignoreAttributes: false,
-        attributeNamePrefix: '',
-        tagValueProcessor: (
-            tagname,
-            tagValue,
-            jPath,
-            hasAttributes,
-            isLeadNode
-        ) => {
-            if (!isLeadNode || typeof tagValue !== 'string') return null
-            return tagValue
-                .split('\n')
-                .map((line) => line.trim())
-                .join('\n')
-        },
-    })
-    const xmlData = parser.parse(fileData)
+    const xmlData = xmlParser.parse(fileData)
     const protocol = transformXMLElement(
         xmlData['protocol'],
         WaylandElementType.Protocol

--- a/scripts/bin/regenerate-protocols-data.ts
+++ b/scripts/bin/regenerate-protocols-data.ts
@@ -51,6 +51,19 @@ async function parseProtocolAndWriteToJSON(srcFileName: string): Promise<void> {
     const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '',
+        tagValueProcessor: (
+            tagname,
+            tagValue,
+            jPath,
+            hasAttributes,
+            isLeadNode
+        ) => {
+            if (!isLeadNode || typeof tagValue !== 'string') return null
+            return tagValue
+                .split('\n')
+                .map((line) => line.trim())
+                .join('\n')
+        },
     })
     const xmlData = parser.parse(fileData)
     const protocol = transformXMLElement(

--- a/src/gitlab-api/index.ts
+++ b/src/gitlab-api/index.ts
@@ -1,9 +1,8 @@
-import { XMLParser } from 'fast-xml-parser'
 import {
     WaylandElementType,
     WaylandProtocol as WaylandProtocolModel,
 } from '../model/wayland'
-import { transformXMLElement } from '../lib/xml-protocol-transformers'
+import { transformXMLElement, xmlParser } from '../lib/xml-protocol-transformers'
 
 export interface GitLabFile {
     name: string
@@ -72,24 +71,7 @@ export async function getMergeRequestFiles(
     }[] = (await response.json()).data.project.repository.blobs.nodes
 
     return nodes.reduce<GitLabFile[]>((out, node) => {
-        const parser = new XMLParser({
-            ignoreAttributes: false,
-            attributeNamePrefix: '',
-            tagValueProcessor: (
-                tagname,
-                tagValue,
-                jPath,
-                hasAttributes,
-                isLeadNode
-            ) => {
-                if (!isLeadNode || typeof tagValue !== 'string') return null
-                return tagValue
-                    .split('\n')
-                    .map((line) => line.trim())
-                    .join('\n')
-            },
-        })
-        const xmlData = parser.parse(node.rawBlob)
+        const xmlData = xmlParser.parse(node.rawBlob)
         const protocol = transformXMLElement<WaylandProtocolModel>(
             xmlData['protocol'],
             WaylandElementType.Protocol

--- a/src/gitlab-api/index.ts
+++ b/src/gitlab-api/index.ts
@@ -75,6 +75,19 @@ export async function getMergeRequestFiles(
         const parser = new XMLParser({
             ignoreAttributes: false,
             attributeNamePrefix: '',
+            tagValueProcessor: (
+                tagname,
+                tagValue,
+                jPath,
+                hasAttributes,
+                isLeadNode
+            ) => {
+                if (!isLeadNode || typeof tagValue !== 'string') return null
+                return tagValue
+                    .split('\n')
+                    .map((line) => line.trim())
+                    .join('\n')
+            },
         })
         const xmlData = parser.parse(node.rawBlob)
         const protocol = transformXMLElement<WaylandProtocolModel>(

--- a/src/lib/xml-protocol-transformers.ts
+++ b/src/lib/xml-protocol-transformers.ts
@@ -1,3 +1,4 @@
+import { XMLParser } from 'fast-xml-parser'
 import {
     WaylandArg,
     WaylandCopyright,
@@ -11,6 +12,24 @@ import {
     WaylandProtocol,
     WaylandRequest,
 } from '../../src/model/wayland'
+
+export const xmlParser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '',
+    tagValueProcessor: (
+        tagname,
+        tagValue,
+        jPath,
+        hasAttributes,
+        isLeadNode
+    ) => {
+        if (!isLeadNode || typeof tagValue !== 'string') return null
+        return tagValue
+            .split('\n')
+            .map((line) => line.trim())
+            .join('\n')
+    },
+})
 
 export function coerceArray<T = any>(value: T | T[]): T[] {
     if (value === null || value === undefined) return []


### PR DESCRIPTION
This fixes lists not working in the MR viewer, e.g. in http://wayland.app/protocols/wayland-protocols/333#xdg_toplevel:request:unset_fullscreen

On an unrelated note, I just discovered URL fragments don't currently work in the MR viewer