### PR TITLE
Fix compositor logos not displaying in MR viewer

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -132,7 +132,7 @@ const CanIUseTable: React.FC<{
                                     {comp.icon && (
                                         <img
                                             alt={comp.name}
-                                            src={`logos/${comp.icon}.svg`}
+                                            src={`/protocols/logos/${comp.icon}.svg`}
                                             className="dark:invert h-5 m-auto"
                                         />
                                     )}


### PR DESCRIPTION
Before:
![Screenshot from 2024-09-04 02-30-06](https://github.com/user-attachments/assets/feda14c9-4ec8-4d4b-9de6-97912179a7b0)

Also, I found out [the commit to fix the outline getting cropped on the top](https://github.com/vially/wayland-explorer/pull/79/commits/728c9b762c7c0defff3efed0a577b96e718e5c65) crops the outline on the bottom xD
I'm noting it here so I don't forget about it.