### PR TITLE
Link to MR rather than to a file

### DIFF
--- a/src/pages/GitLab.tsx
+++ b/src/pages/GitLab.tsx
@@ -220,7 +220,7 @@ export const GitLab: React.FC<{ iid: string }> = ({ iid }) => {
                             name: file.protocol.name,
                             source: WaylandProtocolSource.External,
                             stability: WaylandProtocolStability.Unstable,
-                            externalUrl: `https://gitlab.freedesktop.org${file.webPath}`,
+                            externalUrl: `https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/${iid}`,
                         }}
                     />
                 </div>


### PR DESCRIPTION
As suggested in #87 this replaces the MR Viewer external url with the MR link 