### PR TITLE
Add Jay compositor

### DIFF
--- a/src/data/compositor-registry.ts
+++ b/src/data/compositor-registry.ts
@@ -70,4 +70,9 @@ export const compositorRegistry: CompositorRegistryItem[] = [
         icon: 'Steam_Deck',
         info: require('./compositors/gamescope.json'),
     },
+    {
+        id: 'jay',
+        name: 'Jay',
+        info: require('./compositors/jay.json'),
+    },
 ]

--- a/src/data/compositors/jay.json
+++ b/src/data/compositors/jay.json
@@ -1,0 +1,182 @@
+{
+  "generationTimestamp": 1728720747574,
+  "version": "1.6.1",
+  "globals": [
+    {
+      "interface": "ext_foreign_toplevel_list_v1",
+      "version": 1
+    },
+    {
+      "interface": "ext_idle_notifier_v1",
+      "version": 1
+    },
+    {
+      "interface": "ext_session_lock_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "ext_transient_seat_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "jay_compositor",
+      "version": 10
+    },
+    {
+      "interface": "jay_damage_tracking",
+      "version": 1
+    },
+    {
+      "interface": "org_kde_kwin_server_decoration_manager",
+      "version": 1
+    },
+    {
+      "interface": "wl_compositor",
+      "version": 6
+    },
+    {
+      "interface": "wl_data_device_manager",
+      "version": 3
+    },
+    {
+      "interface": "wl_drm",
+      "version": 2
+    },
+    {
+      "interface": "wl_output",
+      "version": 4
+    },
+    {
+      "interface": "wl_seat",
+      "version": 9
+    },
+    {
+      "interface": "wl_shm",
+      "version": 2
+    },
+    {
+      "interface": "wl_subcompositor",
+      "version": 1
+    },
+    {
+      "interface": "wp_alpha_modifier_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_content_type_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_cursor_shape_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_drm_lease_device_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_fractional_scale_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_linux_drm_syncobj_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_presentation",
+      "version": 1
+    },
+    {
+      "interface": "wp_security_context_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_single_pixel_buffer_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_tearing_control_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_viewporter",
+      "version": 1
+    },
+    {
+      "interface": "xdg_activation_v1",
+      "version": 1
+    },
+    {
+      "interface": "xdg_toplevel_drag_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "xdg_wm_base",
+      "version": 6
+    },
+    {
+      "interface": "xdg_wm_dialog_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwlr_data_control_manager_v1",
+      "version": 2
+    },
+    {
+      "interface": "zwlr_layer_shell_v1",
+      "version": 5
+    },
+    {
+      "interface": "zwlr_screencopy_manager_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwp_idle_inhibit_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_input_method_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_linux_dmabuf_v1",
+      "version": 5
+    },
+    {
+      "interface": "zwp_pointer_constraints_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_pointer_gestures_v1",
+      "version": 3
+    },
+    {
+      "interface": "zwp_primary_selection_device_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_relative_pointer_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zwp_tablet_manager_v2",
+      "version": 1
+    },
+    {
+      "interface": "zwp_text_input_manager_v3",
+      "version": 1
+    },
+    {
+      "interface": "zwp_virtual_keyboard_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_decoration_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "zxdg_output_manager_v1",
+      "version": 3
+    }
+  ]
+}


### PR DESCRIPTION
Jay is not based on any wayland library (wlroots, weston, smithay, etc.) and is not represented by any of the other compositors.

You can find a human-readable list of supported protocols [here][here].

Some globals are not exposed to unprivileged clients. When generating the json file, wlprobe must be invoked as follows: `jay run-privileged -- wlprobe`.

Jay does not have an icon.

[here]: https://github.com/mahkoh/jay/blob/master/docs/features.md#protocol-support