### PR TITLE
Note about new_id serialization caveats

### DIFF
--- a/src/components/WaylandDataTable.tsx
+++ b/src/components/WaylandDataTable.tsx
@@ -1,4 +1,8 @@
-import { isWaylandArgElement, isWaylandEntryElement } from '../model/wayland'
+import {
+    isWaylandArgElement,
+    isWaylandEntryElement,
+    WaylandArgType,
+} from '../model/wayland'
 import {
     WaylandArgModel,
     WaylandEntryModel,
@@ -122,6 +126,32 @@ export const WaylandDataTable: React.FC<{
                 ))}
             </tbody>
         </table>
+
+        {elements.find(
+            (entry) =>
+                isWaylandArgElement(entry) &&
+                entry.argType === WaylandArgType.NewId &&
+                !entry.interface
+        ) && (
+            <div className="border-l-4 border-blue-500 px-4 py-1 my-2">
+                <p className="text-blue-500 flex items-center">
+                    <span className="codicon codicon-info mr-1"></span>Note
+                </p>
+                <p>
+                    <span>Keep in mind that </span>
+                    <span className="bg-gray-100 dark:bg-gray-800 rounded p-1">
+                        new_id
+                    </span>
+                    <span> without defined interface has </span>
+                    <a
+                        className="text-blue-500"
+                        href="https://wayland.freedesktop.org/docs/html/ch04.html#sect-Protocol-Wire-Format"
+                    >
+                        custom serialization rules
+                    </a>
+                </p>
+            </div>
+        )}
     </div>
 )
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b029f654-5b71-4160-aef6-9b55cd33b423)

Not sure if wayland.app is the right place for such niche internal information, but over the years I've seen at least 2 people who struggled to figure out that `new_id` without known interface is supposed to be serialized as 3 arguments `id: new_id, interface: string, version: uint`

So this detects usage of `newid` without `interface` and injects a note that links to [wire format section](https://wayland.freedesktop.org/docs/html/ch04.html#sect-Protocol-Wire-Format) of Wayland docs that mentions this caveat.