### PR TITLE
Louvre: Added SVG logo, updated version and added missing interfaces.

### DIFF
--- a/public/logos/louvre.svg
+++ b/public/logos/louvre.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="184.09608mm"
+   height="127.67956mm"
+   viewBox="0 0 184.09608 127.67956"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs1" /><g
+     id="layer1"
+     transform="translate(-3.4720161,-71.073228)"><g
+       id="g3"
+       transform="matrix(2.9774932,0,0,2.9774932,-272.468,-195.8843)"><path
+         style="fill:#000000;stroke-width:0.264583"
+         d="m 109.35648,109.33141 14.23341,-19.672928 14.23341,19.672928 -14.14275,19.94491 z"
+         id="path1" /><path
+         style="fill:#000000;stroke-width:0.264583"
+         d="m 92.67528,132.54004 11.87629,-16.40922 11.78562,16.40922 z"
+         id="path2" /><path
+         style="fill:#000000;stroke-width:0.264583"
+         d="m 130.93324,132.5284 11.78563,-16.21627 11.78563,16.22791 z"
+         id="path3" /></g></g></svg>

--- a/src/data/compositor-registry.ts
+++ b/src/data/compositor-registry.ts
@@ -90,6 +90,7 @@ export const compositorRegistry: CompositorRegistryItem[] = [
     {
         id: 'louvre',
         name: 'Louvre',
+        icon: 'louvre',
         info: require('./compositors/louvre.json'),
     },
 ]

--- a/src/data/compositors/louvre.json
+++ b/src/data/compositors/louvre.json
@@ -1,6 +1,6 @@
 {
   "generationTimestamp": 1738178000142,
-  "version": "2.14.0",
+  "version": "2.14.1",
   "globals": [
     {
       "interface": "ext_foreign_toplevel_image_capture_source_manager_v1",
@@ -33,6 +33,10 @@
     {
       "interface": "wl_drm",
       "version": 2
+    },
+    {
+      "interface": "wp_drm_lease_device_v1",
+      "version": 1
     },
     {
       "interface": "wl_eglstream_display",
@@ -96,6 +100,10 @@
     },
     {
       "interface": "zwlr_layer_shell_v1",
+      "version": 5
+    },
+    {
+      "interface": "zwp_linux_dmabuf_v1",
       "version": 5
     },
     {


### PR DESCRIPTION
Hi, first of all, thank you for adding Louvre! I’ve made some updates and added a few missing things:

For Louvre:
- Added an SVG logo.
- Updated version to 2.14.1.
- Added the `zwp_linux_dmabuf_v1` and `wp_drm_lease_device_v1` interfaces. These are only available when using the DRM backend, which is likely why they weren’t automatically detected.

I’ve built it, and everything looks good!