### PR TITLE
Fix links to external objects in data tables

### DIFF
--- a/src/components/WaylandDataTable.tsx
+++ b/src/components/WaylandDataTable.tsx
@@ -84,7 +84,9 @@ export const WaylandDataTable: React.FC<{
                                 )}
                                 {element.interface && (
                                     <a
-                                        href={`#${element.interface}`}
+                                        href={`${element.protocol ?? ''}#${
+                                            element.interface
+                                        }`}
                                         className={`font-bold ${colors.Interface}`}
                                     >
                                         {element.interface}


### PR DESCRIPTION
Fixes #128. I haven't used React for a long time, and only barely knew it back then, but this change was simple enough that I could do it myself.

I looked at all the <a> tags in the codebase to see if there are any other similar errors, and couldn't find anything (but this was only a cursory glance).