### PR TITLE
Stop centering compositors table

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -82,7 +82,7 @@ export const WaylandCompositors: React.FC<{
                 </a>
             </h4>
 
-            <div className="flex md:justify-center items-center overflow-x-auto">
+            <div className="flex items-center overflow-x-auto">
                 {rows.length !== 0 ? (
                     <CanIUseTable rows={rows} />
                 ) : (


### PR DESCRIPTION
Flex centering a table that overflows its container doesn't work nicely. The table is so long nowadays that we might as well just drop the centering, and it will look more or less the same.

Before (table is centered and left side is cut off)

![image](https://github.com/user-attachments/assets/8d5d3a2c-134d-422d-93b8-44e417d5c476)

After (table is aligned to left)

![image](https://github.com/user-attachments/assets/91278686-85ec-4728-833e-4a9f056d0053)
