### PR TITLE
Decrease compositor support padding

### DIFF
--- a/src/components/WaylandCompositors.tsx
+++ b/src/components/WaylandCompositors.tsx
@@ -118,12 +118,12 @@ const CanIUseTable: React.FC<{
     }
 
     return (
-        <table className="border-colapse bg-gray-50 rounded dark:bg-neutral-900">
+        <table className="border-collapse bg-gray-50 rounded dark:bg-neutral-900">
             <thead>
                 <tr>
                     <th className="p-4"></th>
                     {compositorRegistry.map((comp) => (
-                        <th key={comp.id} className="px-4 pt-1 align-bottom">
+                        <th key={comp.id} className="px-2 pt-1 align-bottom">
                             <div className="flex flex-col justify-end items-center gap-2">
                                 <div className="[writing-mode:vertical-rl] rotate-180">
                                     {comp.name}


### PR DESCRIPTION
Fixes random tailwind typo and decreases cell padding to hopefully buy us some time until we figure out a better layout.

Before:

![image](https://github.com/user-attachments/assets/bc42d6b3-b3f1-4330-832a-14b2be94e302)

After:
![image](https://github.com/user-attachments/assets/ea993c63-bde1-4f3a-ab2c-718e42ff7569)


related: #138