### PR TITLE
Update kwin.json add missing protocols

### DIFF
--- a/src/data/compositors/kwin.json
+++ b/src/data/compositors/kwin.json
@@ -1,10 +1,14 @@
 {
-  "generationTimestamp": 1739378942698,
-  "version": "6.3",
+  "generationTimestamp": 1750847028130,
+  "version": "6.4",
   "globals": [
     {
-      "interface": "ext_idle_notifier_v1",
+      "interface": "ext_data_control_manager_v1",
       "version": 1
+    },
+    {
+      "interface": "ext_idle_notifier_v1",
+      "version": 2
     },
     {
       "interface": "frog_color_management_factory_v1",
@@ -12,15 +16,23 @@
     },
     {
       "interface": "kde_external_brightness_v1",
-      "version": 2
+      "version": 3
     },
     {
       "interface": "kde_output_device_v2",
-      "version": 11
+      "version": 16
+    },
+    {
+      "interface": "kde_output_device_v2",
+      "version": 16
+    },
+    {
+      "interface": "kde_output_device_v2",
+      "version": 16
     },
     {
       "interface": "kde_output_management_v2",
-      "version": 12
+      "version": 16
     },
     {
       "interface": "kde_output_order_v1",
@@ -83,8 +95,8 @@
       "version": 3
     },
     {
-      "interface": "wl_drm",
-      "version": 2
+      "interface": "wl_output",
+      "version": 4
     },
     {
       "interface": "wl_output",
@@ -96,7 +108,7 @@
     },
     {
       "interface": "wl_shm",
-      "version": 1
+      "version": 2
     },
     {
       "interface": "wl_subcompositor",
@@ -104,6 +116,14 @@
     },
     {
       "interface": "wp_alpha_modifier_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_color_manager_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_color_representation_manager_v1",
       "version": 1
     },
     {
@@ -116,6 +136,10 @@
     },
     {
       "interface": "wp_drm_lease_device_v1",
+      "version": 1
+    },
+    {
+      "interface": "wp_fifo_manager_v1",
       "version": 1
     },
     {
@@ -135,20 +159,16 @@
       "version": 1
     },
     {
+      "interface": "wp_single_pixel_buffer_manager_v1",
+      "version": 1
+    },
+    {
       "interface": "wp_tearing_control_manager_v1",
       "version": 1
     },
     {
       "interface": "wp_viewporter",
       "version": 1
-    },
-    {
-        "interface": "wp_color_manager_v1",
-        "version": 1
-    },
-    {
-        "interface": "wp_color_representation_manager_v1",
-        "version": 1
     },
     {
       "interface": "xdg_activation_v1",
@@ -167,15 +187,15 @@
       "version": 1
     },
     {
+      "interface": "xdg_toplevel_tag_manager_v1",
+      "version": 1
+    },
+    {
       "interface": "xdg_wm_base",
       "version": 6
     },
     {
       "interface": "xdg_wm_dialog_v1",
-      "version": 1
-    },
-    {
-      "interface": "xx_color_manager_v4",
       "version": 1
     },
     {
@@ -196,7 +216,7 @@
     },
     {
       "interface": "zwp_linux_dmabuf_v1",
-      "version": 4
+      "version": 5
     },
     {
       "interface": "zwp_pointer_constraints_v1",
@@ -216,7 +236,7 @@
     },
     {
       "interface": "zwp_tablet_manager_v2",
-      "version": 1
+      "version": 2
     },
     {
       "interface": "zwp_text_input_manager_v1",

--- a/src/data/compositors/kwin.json
+++ b/src/data/compositors/kwin.json
@@ -112,7 +112,7 @@
     },
     {
       "interface": "wp_cursor_shape_manager_v1",
-      "version": 1
+      "version": 2
     },
     {
       "interface": "wp_drm_lease_device_v1",
@@ -141,6 +141,14 @@
     {
       "interface": "wp_viewporter",
       "version": 1
+    },
+    {
+        "interface": "wp_color_manager_v1",
+        "version": 1
+    },
+    {
+        "interface": "wp_color_representation_manager_v1",
+        "version": 1
     },
     {
       "interface": "xdg_activation_v1",


### PR DESCRIPTION
wp_color_representation_manager_v1
wp_color_manager_v1
wp_cursor_shape_manager_v1 version2

Those have been supported by KWin for a while.