### PR TITLE
phoc: Update for 0.55 release

### DIFF
--- a/src/data/compositors/phoc.json
+++ b/src/data/compositors/phoc.json
@@ -1,198 +1,210 @@
 {
-  "generationTimestamp": 1768428266000,
-  "version": "0.52",
+  "generationTimestamp": 1778858491887,
+  "version": "0.55",
   "globals": [
     {
+      "interface": "ext_data_control_manager_v1",
+      "version": 1
+    },
+    {
       "interface": "ext_foreign_toplevel_list_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "ext_idle_notifier_v1",
-      "version": "2"
+      "version": 2
     },
     {
       "interface": "ext_image_copy_capture_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "ext_output_image_capture_source_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "gtk_shell1",
-      "version": "3"
+      "version": 3
     },
     {
       "interface": "org_kde_kwin_server_decoration_manager",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wl_compositor",
-      "version": "6"
+      "version": 6
     },
     {
       "interface": "wl_data_device_manager",
-      "version": "3"
+      "version": 3
     },
     {
       "interface": "wl_drm",
-      "version": "2"
+      "version": 2
     },
     {
       "interface": "wl_output",
-      "version": "4"
+      "version": 4
     },
     {
       "interface": "wl_seat",
-      "version": "9"
+      "version": 9
     },
     {
       "interface": "wl_shm",
-      "version": "2"
+      "version": 2
     },
     {
       "interface": "wl_subcompositor",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wp_alpha_modifier_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wp_cursor_shape_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wp_fractional_scale_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wp_presentation",
-      "version": "2"
+      "version": 2
     },
     {
       "interface": "wp_security_context_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wp_single_pixel_buffer_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "wp_viewporter",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "xdg_activation_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "xdg_wm_base",
-      "version": "6"
+      "version": 6
+    },
+    {
+      "interface": "xdg_wm_dialog_v1",
+      "version": 1
+    },
+    {
+      "interface": "xx_cutouts_manager_v1",
+      "version": 1
     },
     {
       "interface": "zwlr_data_control_manager_v1",
-      "version": "2"
+      "version": 2
     },
     {
       "interface": "zwlr_export_dmabuf_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwlr_foreign_toplevel_manager_v1",
-      "version": "3"
+      "version": 3
     },
     {
       "interface": "zwlr_gamma_control_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwlr_layer_shell_v1",
-      "version": "3"
+      "version": 3
     },
     {
       "interface": "zwlr_output_manager_v1",
-      "version": "4"
+      "version": 4
     },
     {
       "interface": "zwlr_output_power_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwlr_screencopy_manager_v1",
-      "version": "3"
+      "version": 3
     },
     {
       "interface": "zwlr_virtual_pointer_manager_v1",
-      "version": "2"
+      "version": 2
     },
     {
       "interface": "zwp_idle_inhibit_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_input_method_manager_v2",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_keyboard_shortcuts_inhibit_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_linux_dmabuf_v1",
-      "version": "5"
+      "version": 5
     },
     {
       "interface": "zwp_pointer_constraints_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_pointer_gestures_v1",
-      "version": "3"
+      "version": 3
     },
     {
       "interface": "zwp_primary_selection_device_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_relative_pointer_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_tablet_manager_v2",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_text_input_manager_v3",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zwp_virtual_keyboard_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zxdg_decoration_manager_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zxdg_exporter_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zxdg_exporter_v2",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zxdg_importer_v1",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zxdg_importer_v2",
-      "version": "1"
+      "version": 1
     },
     {
       "interface": "zxdg_output_manager_v1",
-      "version": "3"
+      "version": 3
     }
   ]
 }


### PR DESCRIPTION
This switches us to wlprobe generated output (reducing diff noise in the future) and add some small protocol updates.